### PR TITLE
食事摂取基準2025から摂取目標をパラメトリック化（年齢帯・性別・体重・PAL・月経）

### DIFF
--- a/src/app/[locale]/recommendations/[sex]/[weight]/[height]/[age]/[pal_category]/[menstruation]/page.tsx
+++ b/src/app/[locale]/recommendations/[sex]/[weight]/[height]/[age]/[pal_category]/[menstruation]/page.tsx
@@ -9,8 +9,9 @@ import { enUS, jaJP } from '@/locales';
 import {
   loadFoodData,
   optimizeDiet,
-  getReferenceDailyIntakes,
+  buildTarget,
   getDailyCaloryGoal,
+  toAgeBand,
 } from '@/services';
 
 export async function generateStaticParams() {
@@ -20,26 +21,31 @@ export async function generateStaticParams() {
   const ages = ['25', '35', '45'] as const;
   const palCategories = ['low', 'normal', 'high'] as const;
 
-  const filters = sexes.flatMap((sex) =>
+  return sexes.flatMap((sex) =>
     weights.flatMap((weight) =>
       heights.flatMap((height) =>
         ages.flatMap((age) =>
           palCategories.flatMap((pal_category) =>
-            appConfig.i18n.flatMap((locale) => ({
-              sex,
-              weight,
-              height,
-              age,
-              pal_category,
-              locale,
-            }))
+            // 月経ありは女性のみ生成する（男性では鉄の下限に影響しない）。
+            (sex === 'female'
+              ? (['none', 'present'] as const)
+              : (['none'] as const)
+            ).flatMap((menstruation) =>
+              appConfig.i18n.flatMap((locale) => ({
+                sex,
+                weight,
+                height,
+                age,
+                pal_category,
+                menstruation,
+                locale,
+              }))
+            )
           )
         )
       )
     )
   );
-
-  return filters;
 }
 
 export default async function RecommendationPage({
@@ -51,23 +57,29 @@ export default async function RecommendationPage({
     height: string;
     age: string;
     pal_category: 'low' | 'normal' | 'high';
+    menstruation: 'none' | 'present';
     locale: Locale;
   }>;
 }) {
   const foods = await loadFoodData();
   const params = await paramsPromise;
+
+  const age = parseInt(params.age, 10);
+  const weightKg = parseInt(params.weight, 10);
   const dailyCalory = getDailyCaloryGoal(
     params.sex,
-    parseInt(params.age, 10),
-    parseInt(params.weight, 10),
+    age,
+    weightKg,
     params.pal_category
   );
-  const referenceDailyIntakes = getReferenceDailyIntakes(
-    params.sex,
-    parseInt(params.age, 10),
-    parseInt(params.weight, 10),
-    dailyCalory
-  );
+  const referenceDailyIntakes = buildTarget({
+    ageBand: toAgeBand(age),
+    sex: params.sex,
+    weightKg,
+    pal: params.pal_category,
+    menstruation: params.menstruation === 'present',
+  });
+
   const { totalCost, totalNutritionFacts, breakdown } = optimizeDiet(
     foods,
     referenceDailyIntakes
@@ -87,7 +99,13 @@ export default async function RecommendationPage({
                 'This is the result of calculation of your diet for cost and nutrition'
               ]
             }
-            : {messages[params.sex]}, {params.weight}kg, {params.height}cm, {params.age}{messages['years old']}, {messages['physical activity level']}{' '}
+            : {messages[params.sex]}, {params.weight}kg, {params.height}cm,{' '}
+            {params.age}
+            {messages['years old']}
+            {params.menstruation === 'present'
+              ? `, ${messages['menstruating']}`
+              : ''}
+            , {messages['physical activity level']}{' '}
             {messages[params.pal_category]} ({dailyCalory} kcal/日)
           </p>
         </header>

--- a/src/components/user-info-form.tsx
+++ b/src/components/user-info-form.tsx
@@ -16,7 +16,11 @@ export default function UserInfoForm({ locale }: { locale: Locale }) {
     const height = form.height.value;
     const age = form.age.value;
     const pal = form.pal.value;
-    router.push(`/${locale}/recommendations/${sex}/${weight}/${height}/${age}/${pal}`);
+    const menstruation =
+      sex === 'female' && form.menstruation.checked ? 'present' : 'none';
+    router.push(
+      `/${locale}/recommendations/${sex}/${weight}/${height}/${age}/${pal}/${menstruation}`
+    );
   };
 
   return (
@@ -120,6 +124,19 @@ export default function UserInfoForm({ locale }: { locale: Locale }) {
             </option>
           ))}
         </select>
+      </div>
+
+      {/* Menstruation (affects iron requirement for females) */}
+      <div className="flex items-center gap-2">
+        <input
+          id="menstruation"
+          name="menstruation"
+          type="checkbox"
+          className="h-4 w-4 rounded border-gray-300 text-emerald-600 focus:ring-emerald-500"
+        />
+        <label htmlFor="menstruation" className="text-sm text-gray-700">
+          {messages['menstruating']}
+        </label>
       </div>
 
       {/* Physical Activity Level */}

--- a/src/data/dri-2025.ts
+++ b/src/data/dri-2025.ts
@@ -1,0 +1,438 @@
+import { NutritionTarget } from '@/types/nutrition';
+
+/**
+ * 「日本人の食事摂取基準（2025年版）」策定検討会報告書の表から転記した係数・基準値。
+ * すべての数値は報告書の各栄養素の総括表（成人区分）に由来する。式で導出できる栄養素
+ * （エネルギー・たんぱく質・エネルギー比例のビタミン・%エネルギーのマクロ）はここには置かず、
+ * formula 側で算出する。ここに置くのは「式で出せない微量栄養素」の表引き値のみ。
+ *
+ * 出典:
+ * - 報告書トップ: https://www.mhlw.go.jp/stf/newpage_44138.html
+ * - 基礎代謝基準値: エネルギー 表3
+ * - 身体活動レベル: エネルギー 表5（18〜64歳）
+ * - 各微量栄養素: ビタミン／ミネラル 各総括表
+ */
+
+export type Sex = 'male' | 'female';
+export type PalCategory = 'low' | 'normal' | 'high';
+/**
+ * 年齢帯（成人区分）。報告書の成人の区分に一致させる。
+ * 小児・高齢前区分（〜17歳）は本アプリのスコープ外のため未収録。
+ */
+export type AgeBand = '18-29' | '30-49' | '50-64' | '65-74' | '75+';
+
+export const AGE_BANDS: readonly AgeBand[] = [
+  '18-29',
+  '30-49',
+  '50-64',
+  '65-74',
+  '75+',
+];
+
+/**
+ * 基礎代謝基準値（kcal/kg 体重/日）。エネルギー 表3 の (A) 列。
+ * EER = basalMetabolicRate × weightKg × PAL で用いる。
+ */
+export const basalMetabolicRate: Record<AgeBand, Record<Sex, number>> = {
+  '18-29': { male: 23.7, female: 22.1 },
+  '30-49': { male: 22.5, female: 21.9 },
+  '50-64': { male: 21.8, female: 20.7 },
+  '65-74': { male: 21.6, female: 20.7 },
+  '75+': { male: 21.5, female: 20.7 },
+};
+
+/**
+ * 身体活動レベル（PAL）。2025年版で名称が 低い/ふつう/高い に変更された（18〜64歳の代表値）。
+ * 65歳以上では代表値がやや低いが、本アプリは全成人で 18〜64歳の代表値を用いる。
+ */
+export const pal: Record<PalCategory, number> = {
+  low: 1.5,
+  normal: 1.75,
+  high: 2.0,
+};
+
+/**
+ * 式で算出できるビタミンの算定係数（報告書 水溶性ビタミン 各節）。
+ * いずれも推奨量（RDA）＝ 推定平均必要量参照値（EAR）× 推奨量算定係数。
+ */
+export const vitaminCoefficients = {
+  /** B1: EAR 0.30 mg/1,000 kcal × 1.4（2025で 0.45→0.30 に改定） */
+  vitaminB1PerMcal: 0.3 * 1.4,
+  /** B2: EAR 0.50 mg/1,000 kcal × 1.2 */
+  vitaminB2PerMcal: 0.5 * 1.2,
+  /** ナイアシン: EAR 4.8 mgNE/1,000 kcal × 1.2 */
+  niacinPerMcal: 4.8 * 1.2,
+  /** B6: EAR 0.019 mg/g たんぱく質 × 1.2（たんぱく質推奨量に乗じる） */
+  vitaminB6PerProteinGram: 0.019 * 1.2,
+} as const;
+
+/**
+ * たんぱく質推奨量（RDA, g/日）の算定係数。
+ * RDA = 維持必要量(0.66 g/kg/日) ÷ 日常食の消化率(0.90) × 推奨量算定係数(1.25) × 体重。
+ */
+export const proteinCoefficients = {
+  maintenancePerKg: 0.66,
+  digestibility: 0.9,
+  recommendedFactor: 1.25,
+} as const;
+
+/**
+ * %エネルギーで示される栄養素の目標量（DG）。質量換算は formula 側で行う。
+ * 出典: エネルギー産生栄養素バランス／脂質／炭水化物 各表（成人共通）。
+ */
+export const energyPercentTargets = {
+  /** たんぱく質 13〜20%エネルギー */
+  protein: { minPercent: 0.13, maxPercent: 0.2, kcalPerGram: 4 },
+  /** 脂質 20〜30%エネルギー */
+  fat: { minPercent: 0.2, maxPercent: 0.3, kcalPerGram: 9 },
+  /** 飽和脂肪酸 7%エネルギー以下 */
+  saturatedFattyAcids: { maxPercent: 0.07, kcalPerGram: 9 },
+  /** 炭水化物 50〜65%エネルギー */
+  carbohydrates: { minPercent: 0.5, maxPercent: 0.65, kcalPerGram: 4 },
+} as const;
+
+/**
+ * 表引きの微量栄養素（PAL 非依存、年齢帯×性別）。指標種別に応じて min/max を設定する。
+ * - min: EAR/RDA・AI・目標量下限のいずれか
+ * - max: 耐容上限量(UL)・目標量上限のいずれか（設定がなければ省略）
+ *
+ * 鉄(iron)は 2025年版で UL が撤廃されたため max を持たない。女性の月経ありの min は
+ * ironRdaMenstruating で上書きする（[[buildTarget]] 参照）。
+ * 表引きしない栄養素（calories/protein/fat/saturatedFattyAcids/carbohydrates/
+ * vitaminB1/vitaminB2/vitaminB6/niacin）はここに含めない。
+ */
+export type TableMicronutrients = Pick<
+  NutritionTarget,
+  | 'vitaminA'
+  | 'vitaminD'
+  | 'vitaminE'
+  | 'vitaminK'
+  | 'vitaminB12'
+  | 'folate'
+  | 'pantothenicAcid'
+  | 'biotin'
+  | 'vitaminC'
+  | 'nacl'
+  | 'potassium'
+  | 'calcium'
+  | 'magnesium'
+  | 'phosphorus'
+  | 'iron'
+  | 'zinc'
+  | 'copper'
+  | 'manganese'
+  | 'iodine'
+  | 'selenium'
+  | 'chromium'
+  | 'molybdenum'
+  | 'n6PolyunsaturatedFattyAcids'
+  | 'n3PolyunsaturatedFattyAcids'
+  | 'fiber'
+>;
+
+/**
+ * 食塩相当量。EAR相当の下限 1.5 g、上限は高血圧・CKD重症化予防の 6.0 g/日未満（男女共通）。
+ * 目標量(DG)は男性 7.5 g/女性 6.5 g 未満だが、より厳しい重症化予防値を上限に用いる。
+ */
+const nacl = { min: 1.5, max: 6.0 } as const;
+
+// マンガン(AI 男3.5/女3.0, UL 11)・クロム(AI 10, UL 500)・ビオチン(AI 50)・
+// ビタミンB12(AI 4)・ビタミンK(AI 男女150)・ビタミンC(RDA 100) は成人で一定。
+
+export const micronutrientTable: Record<
+  AgeBand,
+  Record<Sex, TableMicronutrients>
+> = {
+  '18-29': {
+    male: {
+      vitaminA: { min: 850, max: 2700 },
+      vitaminD: { min: 9, max: 100 },
+      vitaminE: { min: 6.5, max: 800 },
+      vitaminK: { min: 150 },
+      vitaminB12: { min: 4 },
+      folate: { min: 240, max: 900 },
+      pantothenicAcid: { min: 6 },
+      biotin: { min: 50 },
+      vitaminC: { min: 100 },
+      nacl,
+      potassium: { min: 2500, max: 3000 },
+      calcium: { min: 800, max: 2500 },
+      magnesium: { min: 340 },
+      phosphorus: { min: 1000, max: 3000 },
+      iron: { min: 7.0 },
+      zinc: { min: 9.0, max: 40 },
+      copper: { min: 0.8, max: 7 },
+      manganese: { min: 3.5, max: 11 },
+      iodine: { min: 140, max: 3000 },
+      selenium: { min: 30, max: 400 },
+      chromium: { min: 10, max: 500 },
+      molybdenum: { min: 30, max: 600 },
+      n6PolyunsaturatedFattyAcids: { min: 12 },
+      n3PolyunsaturatedFattyAcids: { min: 2.2 },
+      fiber: { min: 20 },
+    },
+    female: {
+      vitaminA: { min: 650, max: 2700 },
+      vitaminD: { min: 9, max: 100 },
+      vitaminE: { min: 5.0, max: 650 },
+      vitaminK: { min: 150 },
+      vitaminB12: { min: 4 },
+      folate: { min: 240, max: 900 },
+      pantothenicAcid: { min: 5 },
+      biotin: { min: 50 },
+      vitaminC: { min: 100 },
+      nacl,
+      potassium: { min: 2000, max: 2600 },
+      calcium: { min: 650, max: 2500 },
+      magnesium: { min: 280 },
+      phosphorus: { min: 800, max: 3000 },
+      iron: { min: 6.0 },
+      zinc: { min: 7.5, max: 35 },
+      copper: { min: 0.7, max: 7 },
+      manganese: { min: 3.0, max: 11 },
+      iodine: { min: 140, max: 3000 },
+      selenium: { min: 25, max: 350 },
+      chromium: { min: 10, max: 500 },
+      molybdenum: { min: 25, max: 500 },
+      n6PolyunsaturatedFattyAcids: { min: 9 },
+      n3PolyunsaturatedFattyAcids: { min: 1.7 },
+      fiber: { min: 18 },
+    },
+  },
+  '30-49': {
+    male: {
+      vitaminA: { min: 900, max: 2700 },
+      vitaminD: { min: 9, max: 100 },
+      vitaminE: { min: 6.5, max: 800 },
+      vitaminK: { min: 150 },
+      vitaminB12: { min: 4 },
+      folate: { min: 240, max: 1000 },
+      pantothenicAcid: { min: 6 },
+      biotin: { min: 50 },
+      vitaminC: { min: 100 },
+      nacl,
+      potassium: { min: 2500, max: 3000 },
+      calcium: { min: 750, max: 2500 },
+      magnesium: { min: 380 },
+      phosphorus: { min: 1000, max: 3000 },
+      iron: { min: 7.5 },
+      zinc: { min: 9.5, max: 45 },
+      copper: { min: 0.9, max: 7 },
+      manganese: { min: 3.5, max: 11 },
+      iodine: { min: 140, max: 3000 },
+      selenium: { min: 35, max: 450 },
+      chromium: { min: 10, max: 500 },
+      molybdenum: { min: 30, max: 600 },
+      n6PolyunsaturatedFattyAcids: { min: 11 },
+      n3PolyunsaturatedFattyAcids: { min: 2.2 },
+      fiber: { min: 22 },
+    },
+    female: {
+      vitaminA: { min: 700, max: 2700 },
+      vitaminD: { min: 9, max: 100 },
+      vitaminE: { min: 6.0, max: 700 },
+      vitaminK: { min: 150 },
+      vitaminB12: { min: 4 },
+      folate: { min: 240, max: 1000 },
+      pantothenicAcid: { min: 5 },
+      biotin: { min: 50 },
+      vitaminC: { min: 100 },
+      nacl,
+      potassium: { min: 2000, max: 2600 },
+      calcium: { min: 650, max: 2500 },
+      magnesium: { min: 290 },
+      phosphorus: { min: 800, max: 3000 },
+      iron: { min: 6.0 },
+      zinc: { min: 8.0, max: 35 },
+      copper: { min: 0.7, max: 7 },
+      manganese: { min: 3.0, max: 11 },
+      iodine: { min: 140, max: 3000 },
+      selenium: { min: 25, max: 350 },
+      chromium: { min: 10, max: 500 },
+      molybdenum: { min: 25, max: 500 },
+      n6PolyunsaturatedFattyAcids: { min: 9 },
+      n3PolyunsaturatedFattyAcids: { min: 1.7 },
+      fiber: { min: 18 },
+    },
+  },
+  '50-64': {
+    male: {
+      vitaminA: { min: 900, max: 2700 },
+      vitaminD: { min: 9, max: 100 },
+      vitaminE: { min: 6.5, max: 800 },
+      vitaminK: { min: 150 },
+      vitaminB12: { min: 4 },
+      folate: { min: 240, max: 1000 },
+      pantothenicAcid: { min: 6 },
+      biotin: { min: 50 },
+      vitaminC: { min: 100 },
+      nacl,
+      potassium: { min: 2500, max: 3000 },
+      calcium: { min: 750, max: 2500 },
+      magnesium: { min: 370 },
+      phosphorus: { min: 1000, max: 3000 },
+      iron: { min: 7.0 },
+      zinc: { min: 9.5, max: 45 },
+      copper: { min: 0.9, max: 7 },
+      manganese: { min: 3.5, max: 11 },
+      iodine: { min: 140, max: 3000 },
+      selenium: { min: 30, max: 450 },
+      chromium: { min: 10, max: 500 },
+      molybdenum: { min: 30, max: 600 },
+      n6PolyunsaturatedFattyAcids: { min: 11 },
+      n3PolyunsaturatedFattyAcids: { min: 2.3 },
+      fiber: { min: 22 },
+    },
+    female: {
+      vitaminA: { min: 700, max: 2700 },
+      vitaminD: { min: 9, max: 100 },
+      vitaminE: { min: 6.0, max: 700 },
+      vitaminK: { min: 150 },
+      vitaminB12: { min: 4 },
+      folate: { min: 240, max: 1000 },
+      pantothenicAcid: { min: 5 },
+      biotin: { min: 50 },
+      vitaminC: { min: 100 },
+      nacl,
+      potassium: { min: 2000, max: 2600 },
+      calcium: { min: 650, max: 2500 },
+      magnesium: { min: 290 },
+      phosphorus: { min: 800, max: 3000 },
+      iron: { min: 6.0 },
+      zinc: { min: 8.0, max: 35 },
+      copper: { min: 0.7, max: 7 },
+      manganese: { min: 3.0, max: 11 },
+      iodine: { min: 140, max: 3000 },
+      selenium: { min: 25, max: 350 },
+      chromium: { min: 10, max: 500 },
+      molybdenum: { min: 25, max: 500 },
+      n6PolyunsaturatedFattyAcids: { min: 9 },
+      n3PolyunsaturatedFattyAcids: { min: 1.9 },
+      fiber: { min: 18 },
+    },
+  },
+  '65-74': {
+    male: {
+      vitaminA: { min: 850, max: 2700 },
+      vitaminD: { min: 9, max: 100 },
+      vitaminE: { min: 7.0, max: 800 },
+      vitaminK: { min: 150 },
+      vitaminB12: { min: 4 },
+      folate: { min: 240, max: 900 },
+      pantothenicAcid: { min: 6 },
+      biotin: { min: 50 },
+      vitaminC: { min: 100 },
+      nacl,
+      potassium: { min: 2500, max: 3000 },
+      calcium: { min: 750, max: 2500 },
+      magnesium: { min: 350 },
+      phosphorus: { min: 1000, max: 3000 },
+      iron: { min: 7.0 },
+      zinc: { min: 9.0, max: 45 },
+      copper: { min: 0.8, max: 7 },
+      manganese: { min: 3.5, max: 11 },
+      iodine: { min: 140, max: 3000 },
+      selenium: { min: 30, max: 450 },
+      chromium: { min: 10, max: 500 },
+      molybdenum: { min: 30, max: 600 },
+      n6PolyunsaturatedFattyAcids: { min: 10 },
+      n3PolyunsaturatedFattyAcids: { min: 2.3 },
+      fiber: { min: 21 },
+    },
+    female: {
+      vitaminA: { min: 700, max: 2700 },
+      vitaminD: { min: 9, max: 100 },
+      vitaminE: { min: 7.0, max: 700 },
+      vitaminK: { min: 150 },
+      vitaminB12: { min: 4 },
+      folate: { min: 240, max: 900 },
+      pantothenicAcid: { min: 5 },
+      biotin: { min: 50 },
+      vitaminC: { min: 100 },
+      nacl,
+      potassium: { min: 2000, max: 2600 },
+      calcium: { min: 650, max: 2500 },
+      magnesium: { min: 280 },
+      phosphorus: { min: 800, max: 3000 },
+      iron: { min: 6.0 },
+      zinc: { min: 7.5, max: 35 },
+      copper: { min: 0.7, max: 7 },
+      manganese: { min: 3.0, max: 11 },
+      iodine: { min: 140, max: 3000 },
+      selenium: { min: 25, max: 350 },
+      chromium: { min: 10, max: 500 },
+      molybdenum: { min: 25, max: 500 },
+      n6PolyunsaturatedFattyAcids: { min: 9 },
+      n3PolyunsaturatedFattyAcids: { min: 2.0 },
+      fiber: { min: 18 },
+    },
+  },
+  '75+': {
+    male: {
+      vitaminA: { min: 800, max: 2700 },
+      vitaminD: { min: 9, max: 100 },
+      vitaminE: { min: 7.0, max: 800 },
+      vitaminK: { min: 150 },
+      vitaminB12: { min: 4 },
+      folate: { min: 240, max: 900 },
+      pantothenicAcid: { min: 6 },
+      biotin: { min: 50 },
+      vitaminC: { min: 100 },
+      nacl,
+      potassium: { min: 2500, max: 3000 },
+      calcium: { min: 750, max: 2500 },
+      magnesium: { min: 330 },
+      phosphorus: { min: 1000, max: 3000 },
+      iron: { min: 6.5 },
+      zinc: { min: 9.0, max: 40 },
+      copper: { min: 0.8, max: 7 },
+      manganese: { min: 3.5, max: 11 },
+      iodine: { min: 140, max: 3000 },
+      selenium: { min: 30, max: 400 },
+      chromium: { min: 10, max: 500 },
+      molybdenum: { min: 25, max: 600 },
+      n6PolyunsaturatedFattyAcids: { min: 9 },
+      n3PolyunsaturatedFattyAcids: { min: 2.3 },
+      fiber: { min: 20 },
+    },
+    female: {
+      vitaminA: { min: 650, max: 2700 },
+      vitaminD: { min: 9, max: 100 },
+      vitaminE: { min: 6.0, max: 650 },
+      vitaminK: { min: 150 },
+      vitaminB12: { min: 4 },
+      folate: { min: 240, max: 900 },
+      pantothenicAcid: { min: 5 },
+      biotin: { min: 50 },
+      vitaminC: { min: 100 },
+      nacl,
+      potassium: { min: 2000, max: 2600 },
+      calcium: { min: 600, max: 2500 },
+      magnesium: { min: 270 },
+      phosphorus: { min: 800, max: 3000 },
+      iron: { min: 5.5 },
+      zinc: { min: 7.0, max: 35 },
+      copper: { min: 0.7, max: 7 },
+      manganese: { min: 3.0, max: 11 },
+      iodine: { min: 140, max: 3000 },
+      selenium: { min: 25, max: 350 },
+      chromium: { min: 10, max: 500 },
+      molybdenum: { min: 25, max: 500 },
+      n6PolyunsaturatedFattyAcids: { min: 8 },
+      n3PolyunsaturatedFattyAcids: { min: 2.0 },
+      fiber: { min: 17 },
+    },
+  },
+};
+
+/**
+ * 女性・月経ありの鉄の推奨量（RDA, mg/日）。鉄 表（女性・月経あり列）。
+ * 65歳以上には月経ありの区分がないため null（月経なしの値を用いる）。
+ */
+export const ironRdaMenstruating: Record<AgeBand, number | null> = {
+  '18-29': 10.0,
+  '30-49': 10.5,
+  '50-64': 10.5,
+  '65-74': null,
+  '75+': null,
+};

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -1,3 +1,4 @@
 export * from './cross-food-data-reference';
 export * from './manual-food-product-reference';
 export * from './manual-price-food-data-reference';
+export * from './dri-2025';

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -19,6 +19,7 @@
   "height": "height",
   "age": "age",
   "years old": " years old",
+  "menstruating": "menstruating (raises iron requirement)",
   "When most of your daily life is spent sitting and your activities are predominantly static.": "When most of your daily life is spent sitting and your activities are predominantly static.",
   "Your work is mainly sedentary, but you also include any of the following: moving around or standing at work (e.g. serving), commuting, shopping, housework, or light sports.": "Your work is mainly sedentary, but you also include any of the following: moving around or standing at work (e.g. serving), commuting, shopping, housework, or light sports.",
   "You have a job involving a lot of movement or standing, or you maintain an active exercise habit in your leisure time (e.g. regular sports).": "You have a job involving a lot of movement or standing, or you maintain an active exercise habit in your leisure time (e.g. regular sports).",

--- a/src/locales/ja-JP.json
+++ b/src/locales/ja-JP.json
@@ -19,6 +19,7 @@
   "height": "身長",
   "age": "年齢",
   "years old": "歳",
+  "menstruating": "月経あり（鉄の必要量が上がります）",
   "When most of your daily life is spent sitting and your activities are predominantly static.": "生活の大部分が座位で、静的な活動が中心の場合。",
   "Your work is mainly sedentary, but you also include any of the following: moving around or standing at work (e.g. serving), commuting, shopping, housework, or light sports.": "座位中心の仕事だが、職場内での移動や立位での作業・接客等、あるいは通勤・買物・家事、軽いスポーツ等のいずれかを含む場合。",
   "You have a job involving a lot of movement or standing, or you maintain an active exercise habit in your leisure time (e.g. regular sports).": "移動や立位の多い仕事への従事者。あるいは、スポーツなど余暇における活発な運動習慣をもっている場合。",

--- a/src/services/targetAmount.test.ts
+++ b/src/services/targetAmount.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildTarget,
+  estimateEnergyRequirement,
+  proteinRdaGrams,
+} from './targetAmount';
+
+describe('buildTarget (食事摂取基準 2025 パラメトリック化)', () => {
+  it('30代男性・体重70kg・ふつうで現行の基準値と一致（2025改定分を除く）', () => {
+    const target = buildTarget({
+      ageBand: '30-49',
+      sex: 'male',
+      weightKg: 70,
+      pal: 'normal',
+    });
+
+    // EER = 22.5 × 70 × 1.75 = 2756.25（現行の固定値 2750 とほぼ一致）
+    expect(target.calories.equal).toBeCloseTo(2756.25, 2);
+
+    // 表引きの微量栄養素は現行の 30代男性の値と一致する
+    expect(target.vitaminA).toEqual({ min: 900, max: 2700 });
+    expect(target.vitaminD).toEqual({ min: 9, max: 100 });
+    expect(target.calcium).toEqual({ min: 750, max: 2500 });
+    expect(target.iron).toEqual({ min: 7.5 });
+    expect(target.zinc).toEqual({ min: 9.5, max: 45 });
+    expect(target.folate).toEqual({ min: 240, max: 1000 });
+
+    // 式ベースのビタミンは連続計算のため、報告書の丸め値（B1=1.2 等）の1段以内に収まる
+    expect(target.vitaminB1.min).toBeCloseTo(1.16, 1);
+    expect(target.vitaminB2.min).toBeCloseTo(1.65, 1);
+    expect(target.niacin.min).toBeCloseTo(15.9, 0);
+    expect(target.vitaminB6.min).toBeCloseTo(1.46, 1);
+  });
+
+  it('体重を2倍にすると EER と protein_RDA が比例して増える', () => {
+    const single = buildTarget({
+      ageBand: '30-49',
+      sex: 'male',
+      weightKg: 70,
+      pal: 'normal',
+    });
+    const doubled = buildTarget({
+      ageBand: '30-49',
+      sex: 'male',
+      weightKg: 140,
+      pal: 'normal',
+    });
+
+    expect(doubled.calories.equal).toBeCloseTo(single.calories.equal * 2, 5);
+    expect(proteinRdaGrams(140)).toBeCloseTo(proteinRdaGrams(70) * 2, 5);
+    expect(estimateEnergyRequirement('30-49', 'male', 140, 'normal')).toBeCloseTo(
+      estimateEnergyRequirement('30-49', 'male', 70, 'normal') * 2,
+      5
+    );
+  });
+
+  it('女性・月経ありは鉄の下限が月経なしより高い', () => {
+    const withoutMenstruation = buildTarget({
+      ageBand: '30-49',
+      sex: 'female',
+      weightKg: 55,
+      pal: 'normal',
+      menstruation: false,
+    });
+    const withMenstruation = buildTarget({
+      ageBand: '30-49',
+      sex: 'female',
+      weightKg: 55,
+      pal: 'normal',
+      menstruation: true,
+    });
+
+    expect(withMenstruation.iron.min).toBeGreaterThan(
+      withoutMenstruation.iron.min
+    );
+    expect(withoutMenstruation.iron.min).toBe(6.0);
+    expect(withMenstruation.iron.min).toBe(10.5);
+  });
+
+  it('鉄は 2025年版で UL 撤廃のため max を持たない', () => {
+    const target = buildTarget({
+      ageBand: '30-49',
+      sex: 'male',
+      weightKg: 70,
+      pal: 'normal',
+    });
+    expect('max' in target.iron).toBe(false);
+  });
+
+  it('月経ありでも 65歳以上は区分がないため月経なしの値を用いる', () => {
+    const elderly = buildTarget({
+      ageBand: '65-74',
+      sex: 'female',
+      weightKg: 50,
+      pal: 'normal',
+      menstruation: true,
+    });
+    expect(elderly.iron.min).toBe(6.0);
+  });
+});

--- a/src/services/targetAmount.ts
+++ b/src/services/targetAmount.ts
@@ -1,93 +1,167 @@
 import { NutritionTarget } from '@/types/nutrition';
+import {
+  AgeBand,
+  Sex,
+  PalCategory,
+  basalMetabolicRate,
+  pal,
+  vitaminCoefficients,
+  proteinCoefficients,
+  energyPercentTargets,
+  micronutrientTable,
+  ironRdaMenstruating,
+} from '@/data/dri-2025';
 
-const ENERGY_PER_KG_BY_AGE_AND_PAL = {
-  male: {
-    low: [null, null, 59.8, 57.1, 54.2, 46.5, 41.9, 35.6, 33.8, 32.7, 32.4, 30.1],
-    normal: [82.4, 79.5, 68.7, 65.3, 61.7, 52.7, 47.3, 41.5, 39.4, 38.2, 36.7, 36.6],
-    high: [null, null, 77.5, 73.4, 69.2, 58.9, 52.7, 47.4, 45.0, 43.6, 41.0, null]
-  },
-  female: {
-    low: [null, null, 56.6, 53.6, 50.5, 44.4, 39.2, 33.2, 32.9, 31.1, 31.1, 29.0],
-    normal: [80.6, 75.7, 64.9, 61.3, 57.4, 50.3, 44.3, 38.7, 38.3, 36.2, 35.2, 35.2],
-    high: [null, null, 73.3, 68.9, 64.4, 56.2, 49.3, 44.2, 43.8, 41.4, 39.3, null]
-  }
+export type BuildTargetParams = {
+  ageBand: AgeBand;
+  sex: Sex;
+  weightKg: number;
+  pal: PalCategory;
+  /** 女性の月経の有無。鉄の下限に影響する（男性では無視される）。 */
+  menstruation?: boolean;
 };
 
-const getAgeGroupIndex = (age: number): number => {
-  if (age >= 1 && age <= 2) return 0;
-  if (age >= 3 && age <= 5) return 1;
-  if (age >= 6 && age <= 7) return 2;
-  if (age >= 8 && age <= 9) return 3;
-  if (age >= 10 && age <= 11) return 4;
-  if (age >= 12 && age <= 14) return 5;
-  if (age >= 15 && age <= 17) return 6;
-  if (age >= 18 && age <= 29) return 7;
-  if (age >= 30 && age <= 49) return 8;
-  if (age >= 50 && age <= 64) return 9;
-  if (age >= 65 && age <= 74) return 10;
-  if (age >= 75) return 11;
-  return 7; // Default to 18-29 age group
+/**
+ * 年齢（歳）を報告書の成人年齢帯に丸める。17歳以下は最小の成人区分に丸める（スコープ外の暫定）。
+ */
+export const toAgeBand = (age: number): AgeBand => {
+  if (age < 30) return '18-29';
+  if (age < 50) return '30-49';
+  if (age < 65) return '50-64';
+  if (age < 75) return '65-74';
+  return '75+';
 };
 
+/**
+ * 推定エネルギー必要量 EER（kcal/日）= 基礎代謝基準値 × 体重 × 身体活動レベル。
+ * 体重に比例する。
+ */
+export const estimateEnergyRequirement = (
+  ageBand: AgeBand,
+  sex: Sex,
+  weightKg: number,
+  palCategory: PalCategory
+): number => basalMetabolicRate[ageBand][sex] * weightKg * pal[palCategory];
+
+/**
+ * たんぱく質推奨量（RDA, g/日）。維持必要量 ÷ 消化率 × 推奨量算定係数 × 体重。体重に比例する。
+ */
+export const proteinRdaGrams = (weightKg: number): number => {
+  const { maintenancePerKg, digestibility, recommendedFactor } =
+    proteinCoefficients;
+  return (maintenancePerKg / digestibility) * recommendedFactor * weightKg;
+};
+
+const gramsFromEnergyPercent = (
+  energyKcal: number,
+  percent: number,
+  kcalPerGram: number
+): number => (energyKcal * percent) / kcalPerGram;
+
+/**
+ * 目標エネルギー（kcal/日）。EER = 基礎代謝基準値 × 体重 × PAL を丸めた値。
+ */
 export const getDailyCaloryGoal = (
-  sex: 'male' | 'female',
+  sex: Sex,
   age: number,
   weight: number,
-  palCategory: 'low' | 'normal' | 'high'
-): number => {
-  const ageGroupIndex = getAgeGroupIndex(age);
-  const energyPerKg = ENERGY_PER_KG_BY_AGE_AND_PAL[sex][palCategory][ageGroupIndex];
-  
-  if (energyPerKg === null) {
-    const fallbackEnergyPerKg = ENERGY_PER_KG_BY_AGE_AND_PAL[sex]['normal'][ageGroupIndex];
-    return Math.round(weight * (fallbackEnergyPerKg || 35)); // Default fallback
-  }
-  
-  return Math.round(weight * energyPerKg);
-};
+  palCategory: PalCategory
+): number =>
+  Math.round(
+    estimateEnergyRequirement(toAgeBand(age), sex, weight, palCategory)
+  );
+
 /**
- * 日本人の食事摂取基準。単位はいずれも /日 がつく。
- * [「日本人の食事摂取基準（2025年版）」策定検討会報告書](https://www.mhlw.go.jp/stf/newpage_44138.html)
- * [日本人の食事摂取基準（2025年版）の策定ポイント](https://www.mhlw.go.jp/content/12400000/000706_00000.pdf)
+ * buildTarget: 年齢帯・性別・体重・PAL・月経有無から NutritionTarget を組み立てる。
+ *
+ * 指標種別に応じて min（EAR/RDA/AI・目標量下限）と max（耐容上限量 UL・目標量上限）を設定する。
+ * - エネルギー: EER（equal）
+ * - たんぱく質: min = max(RDA体重比例, 目標量下限13%E), max = 目標量上限20%E
+ * - 脂質・飽和脂肪酸・炭水化物: %エネルギー → 質量換算
+ * - B1/B2/ナイアシン: エネルギー比例（per-1,000 kcal 係数 × EER/1000）
+ * - B6: たんぱく質比例（per-g-protein 係数 × たんぱく質RDA）
+ * - それ以外の微量栄養素: [[micronutrientTable]] を表引き（PAL 非依存）
+ * - 鉄: 2025年版で UL 撤廃のため max なし。女性・月経ありは min を上げる。
+ */
+export const buildTarget = ({
+  ageBand,
+  sex,
+  weightKg,
+  pal: palCategory,
+  menstruation = false,
+}: BuildTargetParams): NutritionTarget => {
+  const eer = estimateEnergyRequirement(ageBand, sex, weightKg, palCategory);
+  const eerMcal = eer / 1000;
+  const proteinRda = proteinRdaGrams(weightKg);
+
+  const table = micronutrientTable[ageBand][sex];
+  const { protein, fat, saturatedFattyAcids, carbohydrates } =
+    energyPercentTargets;
+
+  // 鉄: 女性・月経ありは月経あり列の RDA（65歳以上は区分がないため月経なしのまま）。
+  const menstruatingIron =
+    sex === 'female' && menstruation ? ironRdaMenstruating[ageBand] : null;
+  const iron =
+    menstruatingIron !== null ? { min: menstruatingIron } : table.iron;
+
+  return {
+    ...table,
+    calories: { equal: eer },
+    protein: {
+      min: Math.max(
+        proteinRda,
+        gramsFromEnergyPercent(eer, protein.minPercent, protein.kcalPerGram)
+      ),
+      max: gramsFromEnergyPercent(eer, protein.maxPercent, protein.kcalPerGram),
+    },
+    fat: {
+      min: gramsFromEnergyPercent(eer, fat.minPercent, fat.kcalPerGram),
+      max: gramsFromEnergyPercent(eer, fat.maxPercent, fat.kcalPerGram),
+    },
+    saturatedFattyAcids: {
+      max: gramsFromEnergyPercent(
+        eer,
+        saturatedFattyAcids.maxPercent,
+        saturatedFattyAcids.kcalPerGram
+      ),
+    },
+    carbohydrates: {
+      min: gramsFromEnergyPercent(
+        eer,
+        carbohydrates.minPercent,
+        carbohydrates.kcalPerGram
+      ),
+      max: gramsFromEnergyPercent(
+        eer,
+        carbohydrates.maxPercent,
+        carbohydrates.kcalPerGram
+      ),
+    },
+    vitaminB1: { min: vitaminCoefficients.vitaminB1PerMcal * eerMcal },
+    vitaminB2: { min: vitaminCoefficients.vitaminB2PerMcal * eerMcal },
+    niacin: { min: vitaminCoefficients.niacinPerMcal * eerMcal },
+    vitaminB6: {
+      min: vitaminCoefficients.vitaminB6PerProteinGram * proteinRda,
+    },
+    iron,
+  };
+};
+
+/**
+ * 後方互換のための薄いラッパー。旧シグネチャ (sex, age, weight, _dailyCalory) を
+ * buildTarget に委譲する。PAL は「ふつう」、月経なしを既定とする。
+ * @deprecated buildTarget を直接使うこと。
  */
 export const getReferenceDailyIntakes = (
-  sex: 'male' | 'female',
+  sex: Sex,
   age: number,
   weight: number,
-  dailyCalory: number = 2750
-): NutritionTarget => ({
-  calories: { equal: dailyCalory }, // kcal
-  protein: { min: (dailyCalory * 0.13) / 4, max: (dailyCalory * 0.2) / 4 }, // g 13-20%エネルギー 目標。耐容上の指定なし。
-  fat: { min: (dailyCalory * 0.2) / 9, max: (dailyCalory * 0.3) / 9 }, // g. 脂質単位gあたりのエネルギー = 9kcal/g.
-  saturatedFattyAcids: { max: (dailyCalory * 0.07) / 9 }, // 9kcal/g
-  n6PolyunsaturatedFattyAcids: { min: 11 }, // g
-  n3PolyunsaturatedFattyAcids: { min: 2.2 }, // g
-  carbohydrates: { min: (dailyCalory * 0.5) / 4, max: (dailyCalory * 0.65) / 4 }, // 4kcal/g
-  fiber: { min: 29 }, // g • 少なくとも1日当たり25～29gの食物繊維の摂取が、様々な生活習慣病のリスク低下に寄与すると報告されているが、食物繊維摂取量と生活習慣病リスクとの間に明らかな閾値は存在しない。WHOのガイドラインなどを踏まえて、少なくとも1日当たり25gの食物繊維を摂取した方が良いと
-  vitaminA: { min: 900, max: 2700 }, // μg
-  vitaminD: { min: 9, max: 100 }, // μg
-  vitaminE: { min: 6.5, max: 800 }, // mg
-  vitaminK: { min: 150 }, // μg
-  vitaminB1: { min: 1.2 }, // mg
-  vitaminB2: { min: 1.7 }, // mg
-  vitaminB6: { min: 1.5 }, // mg
-  vitaminB12: { min: 4 }, // μg
-  niacin: { min: 16 }, // mg
-  folate: { min: 240, max: 1000 }, // μg 葉酸
-  pantothenicAcid: { min: 6 }, // mg
-  biotin: { min: 50 }, // μg
-  vitaminC: { min: 100 }, // mg
-  nacl: { min: 1.5, max: 6.0 }, // g 高血圧及び慢性腎臓病（CKD）の重症化予防のための食塩相当量の量は、男女とも6.0 g/日未満
-  potassium: { min: 2500, max: 3000 }, // mg カリウム
-  calcium: { min: 750, max: 2500 }, // mg
-  magnesium: { min: 380 }, // mg
-  phosphorus: { min: 1000, max: 3000 }, // mg リン
-  iron: { min: 7.5 }, // mg
-  zinc: { min: 9.5, max: 45 }, // mg
-  copper: { min: 0.9, max: 7 }, // mg
-  manganese: { min: 3.5, max: 11 }, // mg
-  iodine: { min: 140, max: 1400 }, // μg
-  selenium: { min: 35, max: 450 }, // μg
-  chromium: { min: 10, max: 500 }, // μg
-  molybdenum: { min: 30, max: 600 }, // μg
-});
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _dailyCalory: number = 2750
+): NutritionTarget =>
+  buildTarget({
+    ageBand: toAgeBand(age),
+    sex,
+    weightKg: weight,
+    pal: 'normal',
+  });


### PR DESCRIPTION
## 概要
30代男性で固定だった摂取基準を、`buildTarget({ ageBand, sex, weightKg, pal, menstruation })` による **(年齢帯, 性別, 体重, PAL, 月経有無)** のパラメトリック関数に置き換えます。数値はすべて「日本人の食事摂取基準（2025年版）」報告書の表から取得しています。

## 主な変更
- **`src/data/dri-2025.ts`（新規）** — 報告書の表引き値・係数
  - `basalMetabolicRate[ageBand][sex]`（基礎代謝基準値 kcal/kg/日, 表3）
  - `pal = { low: 1.50, normal: 1.75, high: 2.00 }`（表5, 18–64歳）
  - `micronutrientTable[ageBand][sex]` — 式で出せない微量栄養素のみ（各総括表）
  - たんぱく質・ビタミンの算定係数、%エネルギーの目標量
- **`buildTarget`（`src/services/targetAmount.ts`）**
  - `EER = 基礎代謝基準値 × 体重 × PAL`
  - protein RDA ≈ (0.66/0.90)×1.25×体重、B1/B2/ナイアシンはエネルギー比例、B6はたんぱく質比例
  - 脂質・飽和脂肪酸・炭水化物は %エネルギー→質量換算
  - その他の微量栄養素は表引き（PAL非依存）
  - **鉄**: 2025年版で UL 撤廃 → `max` なし。女性・月経ありは `min` を上げる
- **ルート**: 既存の `[sex]/[weight]/[height]/[age]/[pal_category]` に `[menstruation]` を追加。ページは `buildTarget` を呼ぶよう変更（`getReferenceDailyIntakes` は後方互換の薄いラッパーとして存置）
- **フォーム**: 月経チェックボックスを追加
- **テスト**: 体重2倍で EER・protein_RDA が比例／女性・月経ありで鉄 min 上昇 ほか

## 受け入れ条件
- [x] 30代男性の表引き値が現行と一致（式ベースは連続計算で報告書丸め値の1段以内）
- [x] 体重2倍で EER・protein_RDA が比例（単体テスト）
- [x] 女性・月経ありで鉄 min > 月経なし（単体テスト）
- [x] 新ルートパラメータでビルド通過（`next build` 成功、静的生成OK）
- [x] `tsc --noEmit` パス、全テスト green

## 要確認: 現行固定値からの2点の是正（2025改定ではなく、報告書の表への修正）
- **ヨウ素 UL**: 1400 → **3000 µg**（旧固定値は報告書の表と不一致）
- **食物繊維 目標量**: 29 → **22 g**（30-49男。旧値はWHO由来の任意値。報告書DGは年齢帯×性別）

意図的に旧値を使っていた場合は戻せます。

## スコープ外
比較・診断ロジック（PR-D）。UIはパラメータ追加の最小改修のみ。年齢帯は成人（18-29〜75+）に限定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)