### PR TITLE
fix: use semantic route tokens for child weight and toddler PAL

### DIFF
--- a/src/app/[locale]/recommendations/[sex]/[age]/[weight]/[pal_category]/[status]/page.tsx
+++ b/src/app/[locale]/recommendations/[sex]/[age]/[weight]/[pal_category]/[status]/page.tsx
@@ -6,8 +6,10 @@ import NutritionSummary from '@/components/nutrition-summary';
 import {
   appConfig,
   AGE_SEGMENTS,
+  CHILD_WEIGHT_SEGMENT,
   WEIGHT_OPTIONS_KG,
   isChildSegment,
+  palCategoriesFor,
   statusesFor,
   type StatusSegment,
 } from '@/config';
@@ -38,9 +40,9 @@ export async function generateStaticParams() {
       const ageBand = AGE_SEGMENTS[age];
       // 小児は参照体重を用いるため体重を掛け合わせない（区分ごとに1トークン）。
       const weights = isChildSegment(age)
-        ? [String(Math.round(childReferenceWeight[ageBand]!.male))]
+        ? [CHILD_WEIGHT_SEGMENT]
         : WEIGHT_OPTIONS_KG.map(String);
-      const palCategories: PalCategory[] = ['low', 'normal', 'high'];
+      const palCategories = palCategoriesFor(age);
       return weights.flatMap((weight) =>
         palCategories.flatMap((pal_category) =>
           statusesFor(sex, ageBand).flatMap((status) =>

--- a/src/components/user-info-form.tsx
+++ b/src/components/user-info-form.tsx
@@ -3,12 +3,14 @@
 import {
   Locale,
   AGE_SEGMENTS,
+  CHILD_WEIGHT_SEGMENT,
   WEIGHT_OPTIONS_KG,
   isChildSegment,
+  palCategoriesFor,
   statusesFor,
   type StatusSegment,
 } from '@/config';
-import { childReferenceWeight, type Sex } from '@/data';
+import { type Sex } from '@/data';
 import { enUS, jaJP } from '@/locales';
 import { capitalize, toTitleCase } from '@/utils';
 import { useRouter } from 'next/navigation';
@@ -39,15 +41,15 @@ export default function UserInfoForm({ locale }: { locale: Locale }) {
     [sex, ageBand]
   );
   const effectiveStatus = statusOptions.includes(status) ? status : 'none';
+  const palOptions = palCategoriesFor(age);
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const form = e.currentTarget;
-    const pal = form.pal.value;
+    // 1〜5歳は PAL が「ふつう」のみのため選択させず、静的生成と同じトークンを送る。
+    const pal = palOptions.length === 1 ? palOptions[0] : form.pal.value;
     // 小児は参照体重を用いるため体重入力を使わず、静的生成と同じトークンを送る。
-    const weight = isChild
-      ? String(Math.round(childReferenceWeight[ageBand]!.male))
-      : form.weight.value;
+    const weight = isChild ? CHILD_WEIGHT_SEGMENT : form.weight.value;
     router.push(
       `/${locale}/recommendations/${sex}/${age}/${weight}/${pal}/${effectiveStatus}`
     );
@@ -156,56 +158,58 @@ export default function UserInfoForm({ locale }: { locale: Locale }) {
         </div>
       )}
 
-      {/* Physical Activity Level */}
-      <div>
-        <label
-          htmlFor="pal"
-          className="block text-sm font-medium text-gray-700 mb-1"
-        >
-          {toTitleCase(messages['physical activity level'])}
-        </label>
-        <select
-          id="pal"
-          name="pal"
-          required
-          className="block w-full rounded-md border-gray-300 shadow-sm focus:ring-emerald-500 focus:border-emerald-500"
-          defaultValue=""
-        >
-          <option value="" disabled>
-            {messages['select your activity level']}
-          </option>
-          <option value="low">
-            {messages['low']} (
-            {
-              messages[
-                'When most of your daily life is spent sitting and your activities are predominantly static.'
-              ]
-            }
-            )
-          </option>
-          <option value="normal">
-            {messages['normal']} (
-            {
-              messages[
-                'Your work is mainly sedentary, but you also include any of the following: moving around or standing at work (e.g. serving), commuting, shopping, housework, or light sports.'
-              ]
-            }
-            )
-          </option>
-          <option value="high">
-            {messages['high']} (
-            {
-              messages[
-                'You have a job involving a lot of movement or standing, or you maintain an active exercise habit in your leisure time (e.g. regular sports).'
-              ]
-            }
-            )
-          </option>
-        </select>
-        <p className="mt-4 text-xs text-gray-500">
-          {messages['This helps us calculate your daily calorie needs.']}
-        </p>
-      </div>
+      {/* Physical Activity Level (hidden for ages 1-5; only 'normal' is defined) */}
+      {palOptions.length > 1 && (
+        <div>
+          <label
+            htmlFor="pal"
+            className="block text-sm font-medium text-gray-700 mb-1"
+          >
+            {toTitleCase(messages['physical activity level'])}
+          </label>
+          <select
+            id="pal"
+            name="pal"
+            required
+            className="block w-full rounded-md border-gray-300 shadow-sm focus:ring-emerald-500 focus:border-emerald-500"
+            defaultValue=""
+          >
+            <option value="" disabled>
+              {messages['select your activity level']}
+            </option>
+            <option value="low">
+              {messages['low']} (
+              {
+                messages[
+                  'When most of your daily life is spent sitting and your activities are predominantly static.'
+                ]
+              }
+              )
+            </option>
+            <option value="normal">
+              {messages['normal']} (
+              {
+                messages[
+                  'Your work is mainly sedentary, but you also include any of the following: moving around or standing at work (e.g. serving), commuting, shopping, housework, or light sports.'
+                ]
+              }
+              )
+            </option>
+            <option value="high">
+              {messages['high']} (
+              {
+                messages[
+                  'You have a job involving a lot of movement or standing, or you maintain an active exercise habit in your leisure time (e.g. regular sports).'
+                ]
+              }
+              )
+            </option>
+          </select>
+          <p className="mt-4 text-xs text-gray-500">
+            {messages['This helps us calculate your daily calorie needs.']}
+          </p>
+        </div>
+      )}
 
       {/* Submit Button */}
       <button

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-import type { AgeBand, Sex } from '@/data';
+import type { AgeBand, PalCategory, Sex } from '@/data';
 
 export type Locale = 'en-US' | 'ja-JP';
 
@@ -33,11 +33,29 @@ export const AGE_SEGMENTS: Record<string, AgeBand> = {
 export const isChildSegment = (segment: string): boolean =>
   ['1', '3', '6', '8', '10', '12', '15'].includes(segment);
 
+/**
+ * 小児の [weight] ルートセグメント。小児は年齢区分・性別の参照体重で算定し
+ * URL の体重を用いないため、具体的な数値ではなく固定トークンを置く。
+ */
+export const CHILD_WEIGHT_SEGMENT = 'ref';
+
 /** 体重の選択肢（kg, 成人用）。AGE_SEGMENTS と同じ理由でフォームと静的生成で共有する。 */
 export const WEIGHT_OPTIONS_KG: readonly number[] = Array.from(
   { length: 12 },
   (_, i) => 40 + i * 5
 );
+
+/** PAL が「ふつう」のみ設定される小児区分（1〜5歳, エネルギー 表4）。 */
+const SINGLE_PAL_SEGMENTS: readonly string[] = ['1', '3'];
+
+/**
+ * 年齢区分で選択可能な [pal_category] の一覧。1〜5歳は「ふつう」のみ設定される
+ * ため 'normal' の1トークンに畳む。フォームと generateStaticParams の両方が参照する。
+ */
+export const palCategoriesFor = (segment: string): readonly PalCategory[] =>
+  SINGLE_PAL_SEGMENTS.includes(segment)
+    ? ['normal']
+    : ['low', 'normal', 'high'];
 
 /**
  * [status] ルートセグメント（女性の生理・妊娠・授乳の状態）。


### PR DESCRIPTION
## Summary

Two cleanups to the SSG route `/[locale]/recommendations/[sex]/[age]/[weight]/[pal_category]/[status]` around child handling:

- **Child weight segment → fixed `ref` token.** URLs for children embedded the rounded *male* reference weight (e.g. `/female/15/60/...`) while the page actually computes with the sex-specific reference weight (51.9 kg for females 15–17). The number in the URL was unused and misleading. `CHILD_WEIGHT_SEGMENT = 'ref'` is now shared by `generateStaticParams` and the form.
- **Ages 1–5 generate only `pal_category = normal`.** DRI 2025 defines a single PAL (ふつう) for ages 1–2 and 3–5, and low/high were already rounded to normal, producing three identical pages per band. A new `palCategoriesFor()` helper collapses the segment, and the form hides the PAL select for these ages.

Existing static paths for adults and for children aged 6+ are unchanged apart from the weight token. Old child URLs (numeric weight, toddler low/high) will 404 after redeploy since this is a static export.

## Verification

- `tsc --noEmit` clean, all 46 vitest tests pass
- `next build` succeeds; inspected `out/`:
  - `male/1/ref/` contains only `normal`
  - `male/6/ref/` contains `low`/`normal`/`high`
  - `female/15/ref/normal/` has `none` + `menstruation`; `female/30/60/normal/` has all six statuses

🤖 Generated with [Claude Code](https://claude.com/claude-code)