### PR TITLE
Responsive ingredient list, food detail links, and nutrition radar chart

### DIFF
--- a/src/components/ingredients-list.tsx
+++ b/src/components/ingredients-list.tsx
@@ -10,6 +10,285 @@ import {
 } from '@/utils';
 import Link from 'next/link';
 
+type NumericColumn = {
+  key: string;
+  label: (messages: Message) => string;
+  value: (ingredient: FoodRequired) => number;
+  /** md 以上のテーブルでの表示制御。カード表示（モバイル）では全列を表示する。 */
+  tableCellClass: string;
+};
+
+const numericColumns: readonly NumericColumn[] = [
+  {
+    key: 'weight',
+    label: (m) => `${toTitleCase(m['food weight'])} (g)`,
+    value: (i) => i.hectoGrams * 100,
+    tableCellClass: 'table-cell',
+  },
+  {
+    key: 'cost',
+    label: (m) => `${m['food cost']} (${m['yen']})`,
+    value: (i) => i.cost,
+    tableCellClass: 'table-cell',
+  },
+  {
+    key: 'calories',
+    label: (m) => m['calories'],
+    value: (i) => i.nutritionFacts.calories,
+    tableCellClass: 'table-cell',
+  },
+  {
+    key: 'protein',
+    label: (m) => m['protein'],
+    value: (i) => i.nutritionFacts.protein,
+    tableCellClass: 'hidden lg:table-cell',
+  },
+  {
+    key: 'fat',
+    label: (m) => m['fat'],
+    value: (i) => i.nutritionFacts.fat,
+    tableCellClass: 'hidden lg:table-cell',
+  },
+  {
+    key: 'carbohydrates',
+    label: (m) => m['carbohydrates'],
+    value: (i) => i.nutritionFacts.carbohydrates,
+    tableCellClass: 'hidden xl:table-cell',
+  },
+  {
+    key: 'fiber',
+    label: (m) => m['fiber'],
+    value: (i) => i.nutritionFacts.fiber,
+    tableCellClass: 'hidden xl:table-cell',
+  },
+];
+
+const formatAmount = (value: number): string =>
+  value.toLocaleString('ja-JP', { maximumFractionDigits: 0 });
+
+const columnTotal = (
+  column: NumericColumn,
+  ingredients: FoodRequired[]
+): number =>
+  ingredients.reduce((sum, ingredient) => sum + column.value(ingredient), 0);
+
+function ExternalLinkIcon({ className }: { className: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+      <polyline points="15 3 21 3 21 9"></polyline>
+      <line x1="10" y1="14" x2="21" y2="3"></line>
+    </svg>
+  );
+}
+
+/**
+ * 食材名の表示。商品（manual / manualPrice）は商品ページへの外部リンク、
+ * 補足の成分表名は食材詳細ページへの内部リンク。
+ */
+function FoodName({
+  ingredient,
+  messages,
+  locale,
+}: {
+  ingredient: FoodRequired;
+  messages: Message;
+  locale: Locale;
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      {ingredient.type === 'estat' ? (
+        <span className="text-sm font-normal text-emerald-600 line-clamp-2 break-words">
+          {foodDisplayName(ingredient, locale)}
+        </span>
+      ) : (
+        <Link
+          href={ingredient.url}
+          className="group text-sm font-medium text-emerald-600 hover:text-emerald-800 hover:underline inline-flex relative w-full"
+          target="_blank"
+        >
+          <span className="line-clamp-2 pr-1">
+            {foodDisplayName(ingredient, locale)}
+          </span>
+          <ExternalLinkIcon className="h-3 w-3 sm:h-3.5 sm:w-3.5 flex-shrink-0 inline-block align-text-top" />
+        </Link>
+      )}
+      <Link
+        href={`/${locale}/foods/${ingredient.id}`}
+        className="text-xs font-medium text-emerald-600 hover:text-emerald-800 hover:underline break-words"
+      >
+        {foodNutritionFactsName(ingredient, locale) ??
+          capitalize(messages['to nutition factors'])}
+      </Link>
+    </div>
+  );
+}
+
+/** モバイル向けカード表示。テーブルでは入り切らない全項目をラベル付きで見せる。 */
+function IngredientCards({
+  ingredients,
+  messages,
+  locale,
+}: {
+  ingredients: FoodRequired[];
+  messages: Message;
+  locale: Locale;
+}) {
+  const [weight, cost, ...nutrients] = numericColumns;
+  return (
+    <ul className="md:hidden flex flex-col gap-3">
+      {ingredients.map((ingredient) => (
+        <li
+          key={ingredient.id}
+          className="rounded-lg border border-emerald-100 bg-white/60 p-4 shadow-sm"
+        >
+          <FoodName
+            ingredient={ingredient}
+            messages={messages}
+            locale={locale}
+          />
+          <div className="mt-3 flex items-end justify-between border-t border-emerald-100 pt-3">
+            {[weight, cost].map((column) => (
+              <div key={column.key}>
+                <div className="text-xs text-emerald-700">
+                  {column.label(messages)}
+                </div>
+                <div className="text-lg font-bold text-emerald-800 tabular-nums">
+                  {formatAmount(column.value(ingredient))}
+                </div>
+              </div>
+            ))}
+          </div>
+          <dl className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-gray-600">
+            {nutrients.map((column) => (
+              <div key={column.key} className="flex gap-1">
+                <dt>{column.label(messages)}</dt>
+                <dd className="font-medium tabular-nums">
+                  {formatAmount(column.value(ingredient))}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        </li>
+      ))}
+      <li className="rounded-lg bg-emerald-100/70 p-4">
+        <div className="text-sm font-semibold text-emerald-800">
+          {capitalize(messages['total'])}
+        </div>
+        <div className="mt-2 flex items-end justify-between">
+          {[weight, cost].map((column) => (
+            <div key={column.key}>
+              <div className="text-xs text-emerald-700">
+                {column.label(messages)}
+              </div>
+              <div className="text-lg font-bold text-emerald-800 tabular-nums">
+                {formatAmount(columnTotal(column, ingredients))}
+              </div>
+            </div>
+          ))}
+        </div>
+        <dl className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-emerald-800">
+          {nutrients.map((column) => (
+            <div key={column.key} className="flex gap-1">
+              <dt>{column.label(messages)}</dt>
+              <dd className="font-semibold tabular-nums">
+                {formatAmount(columnTotal(column, ingredients))}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      </li>
+    </ul>
+  );
+}
+
+/** md 以上のテーブル表示。数値列は右揃え・等幅数字で桁を揃える。 */
+function IngredientTable({
+  ingredients,
+  messages,
+  locale,
+}: {
+  ingredients: FoodRequired[];
+  messages: Message;
+  locale: Locale;
+}) {
+  return (
+    <div className="hidden md:block relative overflow-x-auto rounded-lg">
+      <table className="min-w-full divide-y divide-emerald-200 table-auto">
+        <thead className="bg-emerald-50">
+          <tr>
+            <th
+              scope="col"
+              className="px-4 py-3 text-left text-xs font-medium text-emerald-700 tracking-wider whitespace-nowrap rounded-tl-lg"
+            >
+              {toTitleCase(messages['food name'])}
+            </th>
+            {numericColumns.map((column) => (
+              <th
+                key={column.key}
+                scope="col"
+                className={`px-4 py-3 text-right text-xs font-medium text-emerald-700 tracking-wider whitespace-nowrap last:rounded-tr-lg ${column.tableCellClass}`}
+              >
+                {column.label(messages)}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className="bg-white divide-y divide-emerald-200">
+          {ingredients.map((ingredient, index) => (
+            <tr
+              key={ingredient.id}
+              className={`${
+                index % 2 === 0 ? 'bg-white/50' : 'bg-emerald-50/50'
+              } hover:bg-emerald-50`}
+            >
+              <td className="px-4 py-3">
+                <FoodName
+                  ingredient={ingredient}
+                  messages={messages}
+                  locale={locale}
+                />
+              </td>
+              {numericColumns.map((column) => (
+                <td
+                  key={column.key}
+                  className={`px-4 py-3 text-right tabular-nums whitespace-nowrap ${column.tableCellClass}`}
+                >
+                  {formatAmount(column.value(ingredient))}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+        <tfoot>
+          <tr className="font-semibold text-emerald-800 bg-emerald-100/70">
+            <td className="px-4 py-3 whitespace-nowrap rounded-bl-lg">
+              {capitalize(messages['total'])}
+            </td>
+            {numericColumns.map((column) => (
+              <td
+                key={column.key}
+                className={`px-4 py-3 text-right tabular-nums whitespace-nowrap last:rounded-br-lg ${column.tableCellClass}`}
+              >
+                {formatAmount(columnTotal(column, ingredients))}
+              </td>
+            ))}
+          </tr>
+        </tfoot>
+      </table>
+    </div>
+  );
+}
+
 export default function IngredientsList({
   ingredients,
   messages,
@@ -20,214 +299,20 @@ export default function IngredientsList({
   locale: Locale;
 }) {
   return (
-    <Card className="p-6 backdrop-blur-sm bg-white/70 rounded-xl shadow-lg">
+    <Card className="p-4 md:p-6 backdrop-blur-sm bg-white/70 rounded-xl shadow-lg">
       <h2 className="text-2xl font-bold text-emerald-800 mb-4">
         {messages['Optimized list of food']}
       </h2>
-
-      <div className="relative overflow-x-auto sm:rounded-lg">
-        <div className="min-w-full inline-block align-middle">
-          <div className="overflow-hidden">
-            <table className="min-w-full divide-y divide-emerald-200 table-auto">
-              <thead className="bg-emerald-50">
-                <tr>
-                  <th
-                    scope="col"
-                    className="px-4 py-3 text-left text-xs font-medium text-emerald-700 uppercase tracking-wider whitespace-nowrap rounded-tl-lg"
-                  >
-                    {toTitleCase(messages['food name'])}
-                  </th>
-                  <th
-                    scope="col"
-                    className="px-4 py-3 text-left text-xs font-medium text-emerald-700 uppercase tracking-wider whitespace-nowrap sm:table-cell hidden"
-                  >
-                    {toTitleCase(messages['food weight'])} (g)
-                  </th>
-                  <th
-                    scope="col"
-                    className="px-4 py-3 text-left text-xs font-medium text-emerald-700 uppercase tracking-wider whitespace-nowrap md:table-cell hidden"
-                  >
-                    {messages['food cost']} ({messages['yen']})
-                  </th>
-                  <th
-                    scope="col"
-                    className="px-4 py-3 text-left text-xs font-medium text-emerald-700 uppercase tracking-wider whitespace-nowrap lg:table-cell hidden"
-                  >
-                    {messages['calories']}
-                  </th>
-                  <th
-                    scope="col"
-                    className="px-4 py-3 text-left text-xs font-medium text-emerald-700 uppercase tracking-wider whitespace-nowrap hidden lg:table-cell"
-                  >
-                    {messages['protein']}
-                  </th>
-                  <th
-                    scope="col"
-                    className="px-4 py-3 text-left text-xs font-medium text-emerald-700 uppercase tracking-wider whitespace-nowrap hidden lg:table-cell"
-                  >
-                    {messages['fat']}
-                  </th>
-                  <th
-                    scope="col"
-                    className="px-4 py-3 text-left text-xs font-medium text-emerald-700 uppercase tracking-wider whitespace-nowrap hidden xl:table-cell"
-                  >
-                    {messages['carbohydrates']}
-                  </th>
-                  <th
-                    scope="col"
-                    className="px-4 py-3 text-left text-xs font-medium text-emerald-700 uppercase tracking-wider whitespace-nowrap hidden xl:table-cell rounded-tr-lg"
-                  >
-                    {messages['fiber']}
-                  </th>
-                </tr>
-              </thead>
-              <tbody className="bg-white divide-y divide-emerald-200">
-                {ingredients.map((ingredient, index) => (
-                  <tr
-                    key={ingredient.id}
-                    className={`${
-                      index % 2 === 0 ? 'bg-white/50' : 'bg-emerald-50/50'
-                    } hover:bg-emerald-50`}
-                  >
-                    <td className="px-4 py-3">
-                      <div className="flex flex-col gap-1">
-                        {ingredient.type === 'estat' ? (
-                          <span className="text-sm font-normal text-emerald-600 line-clamp-2 break-words">
-                            {foodDisplayName(ingredient, locale)}
-                          </span>
-                        ) : (
-                          <Link
-                            href={ingredient.url}
-                            className="group text-sm font-medium text-emerald-600 hover:text-emerald-800 hover:underline inline-flex relative w-full"
-                            target="_blank"
-                          >
-                            <span className="line-clamp-2 pr-1">
-                              {foodDisplayName(ingredient, locale)}
-                            </span>
-                            <svg
-                              xmlns="http://www.w3.org/2000/svg"
-                              viewBox="0 0 24 24"
-                              fill="none"
-                              stroke="currentColor"
-                              strokeWidth="2"
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                              className="h-3 w-3 sm:h-3.5 sm:w-3.5 flex-shrink-0 inline-block align-text-top"
-                            >
-                              <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
-                              <polyline points="15 3 21 3 21 9"></polyline>
-                              <line x1="10" y1="14" x2="21" y2="3"></line>
-                            </svg>
-                          </Link>
-                        )}
-                        <Link
-                          href={`/foods/${ingredient.id}`}
-                          className="text-xs font-medium text-emerald-600 hover:text-emerald-800 hover:underline break-words"
-                        >
-                          {foodNutritionFactsName(ingredient, locale) ??
-                            capitalize(messages['to nutition factors'])}
-                        </Link>
-                      </div>
-                    </td>
-                    <td className="px-4 py-3 whitespace-nowrap sm:table-cell hidden">
-                      {(ingredient.hectoGrams * 100).toLocaleString('ja-JP', {
-                        maximumFractionDigits: 0,
-                      })}
-                    </td>
-                    <td className="px-4 py-3 whitespace-nowrap md:table-cell hidden">
-                      {ingredient.cost.toLocaleString('ja-JP', {
-                        maximumFractionDigits: 0,
-                      })}
-                    </td>
-                    <td className="px-4 py-3 whitespace-nowrap lg:table-cell hidden">
-                      {ingredient.nutritionFacts.calories.toLocaleString(
-                        'ja-JP',
-                        {
-                          maximumFractionDigits: 0,
-                        }
-                      )}
-                    </td>
-                    <td className="px-4 py-3 whitespace-nowrap hidden lg:table-cell">
-                      {ingredient.nutritionFacts.protein.toLocaleString(
-                        'ja-JP',
-                        {
-                          maximumFractionDigits: 0,
-                        }
-                      )}
-                    </td>
-                    <td className="px-4 py-3 whitespace-nowrap hidden lg:table-cell">
-                      {ingredient.nutritionFacts.fat.toLocaleString('ja-JP', {
-                        maximumFractionDigits: 0,
-                      })}
-                    </td>
-                    <td className="px-4 py-3 whitespace-nowrap hidden xl:table-cell">
-                      {ingredient.nutritionFacts.carbohydrates.toLocaleString(
-                        'ja-JP',
-                        {
-                          maximumFractionDigits: 0,
-                        }
-                      )}
-                    </td>
-                    <td className="px-4 py-3 whitespace-nowrap hidden xl:table-cell">
-                      {ingredient.nutritionFacts.fiber.toLocaleString('ja-JP', {
-                        maximumFractionDigits: 0,
-                      })}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-              <tfoot>
-                <tr className="font-semibold text-emerald-800 bg-emerald-100/70">
-                  <td className="px-4 py-3 whitespace-nowrap rounded-bl-lg">
-                    {capitalize(messages['total'])}
-                  </td>
-                  <td className="px-4 py-3 whitespace-nowrap hidden sm:table-cell">
-                    {ingredients
-                      .reduce((sum, ing) => sum + ing.hectoGrams * 100, 0)
-                      .toLocaleString('ja-JP', { maximumFractionDigits: 0 })}
-                  </td>
-                  <td className="px-4 py-3 whitespace-nowrap hidden md:table-cell">
-                    {ingredients
-                      .reduce((sum, ing) => sum + ing.cost, 0)
-                      .toLocaleString('ja-JP', { maximumFractionDigits: 0 })}
-                  </td>
-                  <td className="px-4 py-3 whitespace-nowrap hidden lg:table-cell">
-                    {ingredients
-                      .reduce(
-                        (sum, ing) => sum + ing.nutritionFacts.calories,
-                        0
-                      )
-                      .toLocaleString('ja-JP', { maximumFractionDigits: 0 })}
-                  </td>
-                  <td className="px-4 py-3 whitespace-nowrap hidden lg:table-cell">
-                    {ingredients
-                      .reduce((sum, ing) => sum + ing.nutritionFacts.protein, 0)
-                      .toLocaleString('ja-JP', { maximumFractionDigits: 0 })}
-                  </td>
-                  <td className="px-4 py-3 whitespace-nowrap hidden lg:table-cell">
-                    {ingredients
-                      .reduce((sum, ing) => sum + ing.nutritionFacts.fat, 0)
-                      .toLocaleString('ja-JP', { maximumFractionDigits: 0 })}
-                  </td>
-                  <td className="px-4 py-3 whitespace-nowrap hidden xl:table-cell">
-                    {ingredients
-                      .reduce(
-                        (sum, ing) => sum + ing.nutritionFacts.carbohydrates,
-                        0
-                      )
-                      .toLocaleString('ja-JP', { maximumFractionDigits: 0 })}
-                  </td>
-                  <td className="px-4 py-3 whitespace-nowrap hidden xl:table-cell rounded-br-lg">
-                    {ingredients
-                      .reduce((sum, ing) => sum + ing.nutritionFacts.fiber, 0)
-                      .toLocaleString('ja-JP', { maximumFractionDigits: 0 })}
-                  </td>
-                </tr>
-              </tfoot>
-            </table>
-          </div>
-        </div>
-      </div>
+      <IngredientCards
+        ingredients={ingredients}
+        messages={messages}
+        locale={locale}
+      />
+      <IngredientTable
+        ingredients={ingredients}
+        messages={messages}
+        locale={locale}
+      />
     </Card>
   );
 }

--- a/src/components/nutrition-radar-chart.tsx
+++ b/src/components/nutrition-radar-chart.tsx
@@ -1,6 +1,38 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-import { Message } from '@/locales';
+import type { Message } from '@/locales';
+import { unitMap } from '@/lib/unitmap';
 import type { NutritionFactBase, NutritionTarget } from '@/types/nutrition';
+
+const CENTER_X = 200;
+const CENTER_Y = 168;
+const RADIUS = 112;
+const LABEL_RADIUS = RADIUS + 16;
+const GRID_LEVELS = [0.25, 0.5, 0.75, 1] as const;
+
+const angleOf = (index: number, count: number): number =>
+  (index / count) * 2 * Math.PI;
+
+const pointAt = (angle: number, radius: number): { x: number; y: number } => ({
+  x: CENTER_X + radius * Math.sin(angle),
+  y: CENTER_Y - radius * Math.cos(angle),
+});
+
+const polygonPoints = (radii: readonly number[]): string =>
+  radii
+    .map((radius, index) => {
+      const { x, y } = pointAt(angleOf(index, radii.length), radius);
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(' ');
+
+/** 軸ラベルのアンカー。左右の軸は外側へ、真上・真下は中央揃え。 */
+const anchorOf = (angle: number): 'start' | 'middle' | 'end' => {
+  const sin = Math.sin(angle);
+  if (Math.abs(sin) < 0.15) return 'middle';
+  return sin > 0 ? 'start' : 'end';
+};
+
+const formatAmount = (value: number): string =>
+  value.toLocaleString('ja-JP', { maximumFractionDigits: 1 });
 
 export default function NutritionRadarChart({
   nutritionFacts,
@@ -62,46 +94,114 @@ export default function NutritionRadarChart({
       dailyIntake: referenceDailyIntakes.vitaminA.min,
     },
   ];
-  return <div>🚧 </div>;
-  // return (
-  //   <div className="w-full h-full flex items-center justify-center">
-  //     <div className="text-center">
-  //       <p className="text-emerald-800 mb-2">
-  //         {messages['nutrition rader charts']}
-  //       </p>
-  //       <div className="mt-4 grid grid-cols-2 gap-4">
-  //         {keyNutrients.map((nutrient) => {
-  //           const value =
-  //             nutritionFacts[nutrient.key as keyof NutritionFactBase<number>];
-  //           const percentage = Math.min(
-  //             (value / nutrient.dailyIntake) * 100,
-  //             100
-  //           );
 
-  //           return (
-  //             <div key={nutrient.key} className="text-left">
-  //               <div className="flex justify-between mb-1">
-  //                 <span className="text-sm font-medium text-gray-700">
-  //                   {nutrient.name}
-  //                 </span>
-  //                 <span className="text-sm font-medium text-gray-700">
-  //                   {value.toFixed(1)} /{' '}
-  //                   {nutrient.dailyIntake.toLocaleString('ja-JP', {
-  //                     maximumFractionDigits: 1,
-  //                   })}
-  //                 </span>
-  //               </div>
-  //               <div className="w-full bg-gray-200 rounded-full h-2.5">
-  //                 <div
-  //                   className="h-2.5 rounded-full bg-emerald-500"
-  //                   style={{ width: `${percentage}%` }}
-  //                 ></div>
-  //               </div>
-  //             </div>
-  //           );
-  //         })}
-  //       </div>
-  //     </div>
-  //   </div>
-  // );
+  const axes = keyNutrients.map((nutrient, index) => {
+    const value = nutritionFacts[nutrient.key];
+    const ratio = nutrient.dailyIntake > 0 ? value / nutrient.dailyIntake : 0;
+    return {
+      ...nutrient,
+      index,
+      value,
+      ratio,
+      angle: angleOf(index, keyNutrients.length),
+      unit: unitMap[nutrient.key],
+    };
+  });
+
+  return (
+    <div className="w-full h-full flex flex-col">
+      <svg
+        viewBox="0 0 400 336"
+        className="w-full flex-1 min-h-0"
+        role="img"
+        aria-label={messages['nutrition rader charts']}
+      >
+        {GRID_LEVELS.map((level) => (
+          <polygon
+            key={level}
+            points={polygonPoints(axes.map(() => RADIUS * level))}
+            className="fill-none stroke-emerald-200"
+            strokeWidth="1"
+          />
+        ))}
+        {axes.map((axis) => {
+          const outer = pointAt(axis.angle, RADIUS);
+          return (
+            <line
+              key={axis.key}
+              x1={CENTER_X}
+              y1={CENTER_Y}
+              x2={outer.x.toFixed(1)}
+              y2={outer.y.toFixed(1)}
+              className="stroke-emerald-200"
+              strokeWidth="1"
+            />
+          );
+        })}
+        {GRID_LEVELS.map((level) => (
+          <text
+            key={level}
+            x={CENTER_X + 4}
+            y={CENTER_Y - RADIUS * level + 3}
+            className="fill-gray-400"
+            fontSize="8"
+          >
+            {level * 100}%
+          </text>
+        ))}
+        <polygon
+          points={polygonPoints(
+            axes.map((axis) => RADIUS * Math.min(axis.ratio, 1))
+          )}
+          className="fill-emerald-500/25 stroke-emerald-600"
+          strokeWidth="2"
+          strokeLinejoin="round"
+        />
+        {axes.map((axis) => {
+          const point = pointAt(axis.angle, RADIUS * Math.min(axis.ratio, 1));
+          return (
+            <circle
+              key={axis.key}
+              cx={point.x.toFixed(1)}
+              cy={point.y.toFixed(1)}
+              r="3"
+              className="fill-emerald-600"
+            >
+              <title>
+                {`${axis.name}: ${formatAmount(axis.value)} ${axis.unit} / ${formatAmount(axis.dailyIntake)} ${axis.unit}`}
+              </title>
+            </circle>
+          );
+        })}
+        {axes.map((axis) => {
+          const point = pointAt(axis.angle, LABEL_RADIUS);
+          // 真上の軸はラベルを上へ、真下の軸は下へ逃がして重なりを防ぐ
+          const yOffset = -Math.cos(axis.angle) * 8;
+          return (
+            <text
+              key={axis.key}
+              x={point.x.toFixed(1)}
+              y={(point.y + yOffset).toFixed(1)}
+              textAnchor={anchorOf(axis.angle)}
+              className="fill-gray-700"
+              fontSize="11"
+            >
+              <tspan>{axis.name}</tspan>
+              <tspan
+                x={point.x.toFixed(1)}
+                dy="12"
+                className="fill-emerald-700 font-semibold"
+                fontSize="10"
+              >
+                {Math.round(axis.ratio * 100).toLocaleString('ja-JP')}%
+              </tspan>
+            </text>
+          );
+        })}
+      </svg>
+      <p className="text-xs text-gray-500 text-center">
+        {messages['Share of daily reference intake per 100 g']}
+      </p>
+    </div>
+  );
 }

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -47,6 +47,7 @@
   "The bar length indicates relative score": "The bar length indicates relative score",
   "to nutition factors": "to nutrition facts",
   "details": "details",
+  "Share of daily reference intake per 100 g": "share of daily reference intake per 100 g edible portion",
   "nutrition rader charts": "nutrition rader charts",
   "calories": "calories",
   "protein": "protein",

--- a/src/locales/ja-JP.json
+++ b/src/locales/ja-JP.json
@@ -47,6 +47,7 @@
   "The bar length indicates relative score": "バーの長さは各カテゴリー内での相対値を表しています",
   "to nutition factors": "栄養成分へ",
   "details": "details",
+  "Share of daily reference intake per 100 g": "可食部100gあたり・1日基準量に対する割合",
   "nutrition rader charts": "栄養素レーダーチャート",
   "calories": "カロリー",
   "protein": "タンパク質",


### PR DESCRIPTION
## Summary

- **Responsive ingredient list**: the optimized food list table collapsed to a single name column on mobile. Below the `md` breakpoint it now renders as cards showing every figure — weight and cost prominently, with calories/protein/fat/carbohydrates/fiber as labeled rows — plus a totals card. On wider screens the table remains, with right-aligned `tabular-nums` numeric columns. Header, rows, and totals are generated from one column-definition array.
- **Fix 404 on food detail links**: the list linked to `/foods/{id}` without the locale prefix, which 404s under static export. Now links to `/{locale}/foods/{id}`.
- **Nutrition balance radar chart**: the detail page's 🚧 placeholder (the reason the pages were left unlinked) is replaced with a static SVG radar chart — a server component with no chart dependency. Nine key nutrients are plotted as the share of daily reference intake per 100 g (capped at 100%), with per-axis percentage labels and native tooltips showing raw amounts against the reference. Caption string added to both locales.

## Test plan

- `pnpm test` — 46 tests pass (incl. the no-hardcoded-Japanese guard)
- `tsc --noEmit` clean
- Verified in dev server: mobile (375px) card list, desktop table, detail-page navigation from the list, and radar chart rendering on `/ja-JP/foods/{id}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)