### PR TITLE
fix: remove duplicate apple entry causing React duplicate key errors

### DIFF
--- a/src/data/cross-food-data-reference.ts
+++ b/src/data/cross-food-data-reference.ts
@@ -220,10 +220,6 @@ export const crossFoodReference: CrossFoodDataReference[] = [
     shokuhinbangou: '06236',
   },
   {
-    estatId: 1502, // りんご
-    shokuhinbangou: '07176',
-  },
-  {
     estatId: 1511, // みかん
     shokuhinbangou: '07027',
   },

--- a/src/services/load-food-data.ts
+++ b/src/services/load-food-data.ts
@@ -203,6 +203,23 @@ export const loadFoodData = async (): Promise<FoodToOptimize[]> => {
     })),
   ];
 
+  // id は名前由来のハッシュなので、参照データに同じ食材が二重登録されると衝突する。
+  // React の key 重複などにつながるため、ビルド時に落として登録ミスを検知する。
+  const duplicateIds = foods
+    .map((food) => food.id)
+    .filter((id, index, ids) => ids.indexOf(id) !== index);
+  if (duplicateIds.length > 0) {
+    const duplicates = foods
+      .filter((food) => duplicateIds.includes(food.id))
+      .map((food) =>
+        'nameInEstat' in food ? food.nameInEstat : food.productName
+      );
+    throw new Error(
+      `Duplicate food ids detected: ${[...new Set(duplicates)].join(', ')}. ` +
+        'Check for duplicate entries in src/data.'
+    );
+  }
+
   cachedData = foods;
   return foods;
 };


### PR DESCRIPTION
## Summary
- `crossFoodReference` had two identical entries for apple (`estatId: 1502`, `shokuhinbangou: '07176'`). The second one was accidentally re-added in 8c7736a ("Add new food items to cross-food data reference").
- Food ids are `sha256(nameInEstat + nameInNutritionFacts)`, so both entries produced the same id (`03bc317e...`), causing React duplicate key errors on the `/[locale]/compare` Hasse diagram.
- Removed the duplicate entry and added a duplicate-id guard in `loadFoodData` that throws at build time with the offending food names, so future double registrations in `src/data` fail fast instead of surfacing as React key warnings.

## Testing
- `pnpm vitest run` — all tests pass; no snapshot updates needed (apple is not part of the price snapshot set).
- Verified in the dev server that `/ja-JP/compare` renders the Hasse diagram with a single apple entry and zero console errors/warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)