### PR TITLE
feat: connect recommendations, food database, and Hasse diagram

### DIFF
--- a/src/app/[locale]/compare/page.tsx
+++ b/src/app/[locale]/compare/page.tsx
@@ -1,3 +1,5 @@
+import { Suspense } from 'react';
+
 import FoodComparison from '@/components/food-comparison';
 import { appConfig, type Locale } from '@/config';
 import { enUS, jaJP } from '@/locales';
@@ -29,11 +31,14 @@ export default async function ComparePage({
             {messages['compare page description']}
           </p>
         </header>
-        <FoodComparison
-          foods={foods}
-          messages={messages}
-          locale={params.locale}
-        />
+        {/* useSearchParams（?highlight=）を使うため Suspense 境界が必要 */}
+        <Suspense>
+          <FoodComparison
+            foods={foods}
+            messages={messages}
+            locale={params.locale}
+          />
+        </Suspense>
       </div>
     </div>
   );

--- a/src/app/[locale]/foods/[id]/page.tsx
+++ b/src/app/[locale]/foods/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from 'next/navigation';
 import { Card } from '@/components/ui/card';
+import FoodDominationCard from '@/components/food-domination-card';
 import NutritionFactsTable from '@/components/nutrition-facts-table';
 import NutritionRadarChart from '@/components/nutrition-radar-chart';
 import CostEfficiencyChart from '@/components/cost-efficiency-chart';
@@ -178,6 +179,14 @@ export default async function FoodPage({
               </div>
             </div>
           </Card>
+
+          {/* コスト・栄養トレードオフ上の位置（局所半順序） */}
+          <FoodDominationCard
+            food={food}
+            foods={foods}
+            messages={messages}
+            locale={locale}
+          />
 
           {/* 栄養素レーダーチャートとコスト効率 */}
           <div className="grid md:grid-cols-2 gap-8">

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,6 +1,8 @@
 import { LanguageSwitch } from '@/components/language-switcher';
+import { SiteNav } from '@/components/site-nav';
 import ThemeImage from '@/components/theme-image';
 import { appConfig, basePath, Locale } from '@/config';
+import { enUS, jaJP } from '@/locales';
 import Link from 'next/link';
 import { Suspense } from 'react';
 
@@ -14,30 +16,39 @@ export default async function LocaleLayout({
   }>;
 }>) {
   const { locale } = await params;
+  const messages = locale === 'ja-JP' ? jaJP : enUS;
 
   return (
     <>
-      <header
-        style={{ display: 'flex', justifyContent: 'flex-end', gap: '1rem' }}
-      >
-        <Suspense>
-          <LanguageSwitch locale={locale} locales={appConfig.i18n} />
-        </Suspense>
-        <Link
-          href="https://github.com/nwatab/nutrition-optimizer"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="flex items-center gap-2 p-2 rounded-lg hover:bg-emerald-100 transition-colors"
-        >
-          <ThemeImage
-            srcLight={`${basePath}/github-mark.svg`}
-            // srcDark={`${basePath}/github-mark-white.svg`} ToDo
-            srcDark={`${basePath}/github-mark.svg`}
-            alt="GitHub"
-            width={24}
-            height={24}
-          />
-        </Link>
+      <header className="flex items-center justify-between gap-2 px-2 py-1 overflow-x-auto">
+        <SiteNav
+          locale={locale}
+          labels={{
+            recommendations: messages['My plan'],
+            foods: messages['Food database'],
+            compare: messages.Compare,
+          }}
+        />
+        <div className="flex items-center gap-2">
+          <Suspense>
+            <LanguageSwitch locale={locale} locales={appConfig.i18n} />
+          </Suspense>
+          <Link
+            href="https://github.com/nwatab/nutrition-optimizer"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-2 p-2 rounded-lg hover:bg-emerald-100 transition-colors"
+          >
+            <ThemeImage
+              srcLight={`${basePath}/github-mark.svg`}
+              // srcDark={`${basePath}/github-mark-white.svg`} ToDo
+              srcDark={`${basePath}/github-mark.svg`}
+              alt="GitHub"
+              width={24}
+              height={24}
+            />
+          </Link>
+        </div>
       </header>
 
       {children}

--- a/src/app/[locale]/recommendations/[sex]/[age]/[weight]/[pal_category]/[status]/page.tsx
+++ b/src/app/[locale]/recommendations/[sex]/[age]/[weight]/[pal_category]/[status]/page.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link';
+
 import IngredientsList from '@/components/ingredients-list';
 import IngredientsListDetail from '@/components/ingredients-list-detail';
 import NutritionCategoryCharts from '@/components/nutrition-category-charts';
@@ -131,6 +133,18 @@ export default async function RecommendationPage({
             messages={messages}
             locale={params.locale}
           />
+          {/* 選定根拠への導線: 選ばれた食材を Hasse 図上でハイライトする */}
+          <p className="-mt-4 text-center">
+            <Link
+              href={`/${params.locale}/compare?highlight=${breakdown
+                .map((ingredient) => encodeURIComponent(ingredient.id))
+                .join(',')}`}
+              className="text-sm text-emerald-700 underline hover:text-emerald-900"
+            >
+              {messages['Why these foods? See the rationale on the Hasse diagram']}{' '}
+              →
+            </Link>
+          </p>
           <IngredientsListDetail
             ingredients={breakdown}
             referenceDailyIntakes={referenceDailyIntakes}

--- a/src/components/food-comparison.tsx
+++ b/src/components/food-comparison.tsx
@@ -1,15 +1,17 @@
 'use client';
 
+import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
 import { useMemo, useState } from 'react';
 
+import { HasseDiagram, truncate } from '@/components/hasse-diagram';
 import { Card, CardContent } from '@/components/ui/card';
 import type { Locale } from '@/config';
 import type { Message } from '@/locales';
 import type { NutrientKey } from '@/services/diagnose';
 import {
-  hasseEdges,
+  DEFAULT_COMPARE_NUTRIENT_KEYS,
   rankByScalarizedCost,
-  skyline,
   type ScalarizationWeights,
 } from '@/services/domination';
 import { toCompareNode, type CompareNode } from '@/services/environment';
@@ -64,172 +66,17 @@ const BASIS_LABELS: Record<Basis, keyof Message> = {
   perKcal: 'per 1 kcal',
 };
 
-/** Hasse 図の層。支配する側が上（層0 = どこからも支配されない）。 */
-const computeLayers = (
-  nodes: CompareNode[],
-  edges: { from: string; to: string }[]
-): Map<string, number> => {
-  const parents = new Map<string, string[]>();
-  edges.forEach(({ from, to }) =>
-    parents.set(to, [...(parents.get(to) ?? []), from])
-  );
-  const memo = new Map<string, number>();
-  const layerOf = (id: string): number => {
-    const cached = memo.get(id);
-    if (cached !== undefined) return cached;
-    const dominators = parents.get(id) ?? [];
-    const layer =
-      dominators.length === 0 ? 0 : 1 + Math.max(...dominators.map(layerOf));
-    memo.set(id, layer);
-    return layer;
-  };
-  nodes.forEach((node) => layerOf(node.id));
-  return memo;
-};
-
-const truncate = (text: string, length: number): string =>
-  text.length > length ? `${text.slice(0, length)}…` : text;
-
-const NODE_WIDTH = 128;
-const NODE_HEIGHT = 34;
-const LAYER_GAP = 110;
-const COLUMN_GAP = 12;
-
-const HasseDiagram = ({
-  nodes,
-  nutrientKeys,
-  messages,
-}: {
-  nodes: CompareNode[];
-  nutrientKeys: NutrientKey[];
-  messages: Message;
-}) => {
-  const edges = useMemo(
-    () => hasseEdges(nodes, nutrientKeys),
-    [nodes, nutrientKeys]
-  );
-  const front = useMemo(
-    () => new Set(skyline(nodes, nutrientKeys).map((n) => n.id)),
-    [nodes, nutrientKeys]
-  );
-  const layers = useMemo(() => computeLayers(nodes, edges), [nodes, edges]);
-
-  const nodesByLayer = useMemo(() => {
-    const grouped = new Map<number, CompareNode[]>();
-    nodes.forEach((node) => {
-      const layer = layers.get(node.id) ?? 0;
-      grouped.set(layer, [...(grouped.get(layer) ?? []), node]);
-    });
-    return grouped;
-  }, [nodes, layers]);
-
-  const positions = useMemo(
-    () =>
-      new Map(
-        [...nodesByLayer.entries()].flatMap(([layer, layerNodes]) =>
-          layerNodes.map((node, index) => [
-            node.id,
-            {
-              x: index * (NODE_WIDTH + COLUMN_GAP) + NODE_WIDTH / 2,
-              y: layer * LAYER_GAP + NODE_HEIGHT / 2 + 10,
-            },
-          ])
-        )
-      ),
-    [nodesByLayer]
-  );
-
-  const width =
-    Math.max(...[...nodesByLayer.values()].map((ns) => ns.length)) *
-    (NODE_WIDTH + COLUMN_GAP);
-  const height = (Math.max(...[...layers.values()], 0) + 1) * LAYER_GAP + 20;
-
-  const tooltip = (node: CompareNode): string =>
-    [
-      node.label,
-      `${messages['intake form']}: ${messages[node.intakeForm]} / ${messages.distribution}: ${messages.retail} / ${node.productionMethod === 'organic' ? messages.organic : messages.conventional}`,
-      ...nutrientKeys.map(
-        (key) => `${messages[key]}: ${node.nutrientDensity[key].toPrecision(3)}`
-      ),
-      `${messages.yen}: ${node.costVector.yen.toPrecision(3)}`,
-      `CO2e: ${node.costVector.co2eKg.toPrecision(3)} kg`,
-      `${messages.land}: ${node.costVector.landM2.toPrecision(3)} m²`,
-      `${messages.water}: ${node.costVector.waterL.toPrecision(3)} L`,
-      ...(node.pesticideResidue
-        ? [
-            messages[
-              'pesticide residue: present (health impact not assessed)'
-            ],
-          ]
-        : []),
-    ].join('\n');
-
-  return (
-    <div className="overflow-x-auto">
-      <svg width={width} height={height} className="min-w-full">
-        {edges.map(({ from, to }) => {
-          const a = positions.get(from);
-          const b = positions.get(to);
-          if (!a || !b) return null;
-          return (
-            <line
-              key={`${from}-${to}`}
-              x1={a.x}
-              y1={a.y + NODE_HEIGHT / 2}
-              x2={b.x}
-              y2={b.y - NODE_HEIGHT / 2}
-              stroke="#94a3b8"
-              strokeWidth={1}
-            />
-          );
-        })}
-        {nodes.map((node) => {
-          const position = positions.get(node.id);
-          if (!position) return null;
-          const organic = node.productionMethod === 'organic';
-          const dominated = !front.has(node.id);
-          return (
-            <g
-              key={node.id}
-              transform={`translate(${position.x - NODE_WIDTH / 2}, ${position.y - NODE_HEIGHT / 2})`}
-              // 支配されたノード（有機を含む）も隠さず、薄くして表示する
-              opacity={dominated ? 0.55 : 1}
-            >
-              <title>{tooltip(node)}</title>
-              <rect
-                width={NODE_WIDTH}
-                height={NODE_HEIGHT}
-                rx={6}
-                fill={organic ? '#dcfce7' : '#ffffff'}
-                stroke={organic ? '#16a34a' : '#64748b'}
-                strokeWidth={front.has(node.id) ? 2 : 1}
-              />
-              <text x={6} y={14} fontSize={10} fill="#0f172a">
-                {truncate(node.label, 12)}
-                {organic ? ' 🌱' : ''}
-              </text>
-              <text x={6} y={27} fontSize={9} fill="#475569">
-                {messages[node.intakeForm]}
-                {dominated ? ` / ${messages.dominated}` : ''}
-                {node.pesticideResidue
-                  ? ` / ${messages['pesticide residue (not assessed)']}`
-                  : ''}
-              </text>
-            </g>
-          );
-        })}
-      </svg>
-    </div>
-  );
-};
-
 const ScalarizedRanking = ({
   nodes,
   weights,
+  highlightedIds,
+  locale,
   messages,
 }: {
   nodes: CompareNode[];
   weights: ScalarizationWeights;
+  highlightedIds: ReadonlySet<string>;
+  locale: Locale;
   messages: Message;
 }) => {
   const ranking = useMemo(
@@ -259,10 +106,20 @@ const ScalarizedRanking = ({
       </thead>
       <tbody>
         {ranking.map(({ node, totalCost }, index) => (
-          <tr key={node.id} className="border-b border-gray-100">
+          <tr
+            key={node.id}
+            className={`border-b border-gray-100 ${
+              highlightedIds.has(node.id) ? 'bg-amber-50' : ''
+            }`}
+          >
             <td className="py-1 pr-2 text-gray-500">{index + 1}</td>
             <td className="py-1 pr-2">
-              {truncate(node.label, 24)}
+              <Link
+                href={`/${locale}/foods/${node.foodId}`}
+                className="hover:text-emerald-800 hover:underline"
+              >
+                {truncate(node.label, 24)}
+              </Link>
               {node.productionMethod === 'organic' && (
                 <span className="ml-1 rounded bg-green-100 px-1 text-xs text-green-700">
                   {messages.organic}
@@ -309,13 +166,21 @@ export default function FoodComparison({
   messages: Message;
   locale: Locale;
 }) {
+  const searchParams = useSearchParams();
+  // 導線元（リコメンド・食品詳細）から ?highlight=id1,id2 で注目食材を受け取る
+  const highlightedIds = useMemo(
+    () =>
+      new Set(
+        (searchParams.get('highlight') ?? '').split(',').filter(Boolean)
+      ),
+    [searchParams]
+  );
+
   const [basis, setBasis] = useState<Basis>('per100g');
   const [mode, setMode] = useState<'pareto' | 'scalarized'>('pareto');
-  const [nutrientKeys, setNutrientKeys] = useState<NutrientKey[]>([
-    'protein',
-    'fiber',
-    'vitaminC',
-  ]);
+  const [nutrientKeys, setNutrientKeys] = useState<NutrientKey[]>(
+    DEFAULT_COMPARE_NUTRIENT_KEYS
+  );
   // p_* はユーザー設定。デフォルト 0（円のみのランキングに一致）。
   // p_co2 の参照アンカー: J-クレジット取引価格（数千円/t-CO2e ≈ 数円/kg）〜
   // 炭素の社会的費用（数万円/t-CO2e ≈ 数十円/kg）。採否はユーザーに委ねる。
@@ -457,12 +322,16 @@ export default function FoodComparison({
             <HasseDiagram
               nodes={nodes}
               nutrientKeys={nutrientKeys}
+              highlightedIds={[...highlightedIds]}
+              locale={locale}
               messages={messages}
             />
           ) : (
             <ScalarizedRanking
               nodes={nodes}
               weights={weights}
+              highlightedIds={highlightedIds}
+              locale={locale}
               messages={messages}
             />
           )}

--- a/src/components/food-domination-card.tsx
+++ b/src/components/food-domination-card.tsx
@@ -1,0 +1,149 @@
+import Link from 'next/link';
+
+import { HasseDiagram } from '@/components/hasse-diagram';
+import { Card } from '@/components/ui/card';
+import type { Locale } from '@/config';
+import type { Message } from '@/locales';
+import {
+  DEFAULT_COMPARE_NUTRIENT_KEYS,
+  dominates,
+} from '@/services/domination';
+import { toCompareNode, type CompareNode } from '@/services/environment';
+import type { FoodToOptimize } from '@/types/nutrition';
+
+const MAX_LISTED = 6;
+
+/**
+ * 支配関係にある食材のリスト。多すぎる場合は先頭 MAX_LISTED 件 + 残数。
+ */
+function NodeList({
+  nodes,
+  locale,
+  messages,
+}: {
+  nodes: CompareNode[];
+  locale: Locale;
+  messages: Message;
+}) {
+  if (nodes.length === 0) {
+    return <p className="text-sm text-gray-400">{messages['(none)']}</p>;
+  }
+  const listed = nodes.slice(0, MAX_LISTED);
+  const rest = nodes.length - listed.length;
+  return (
+    <ul className="flex flex-wrap gap-2">
+      {listed.map((node) => (
+        <li key={node.id}>
+          <Link
+            href={`/${locale}/foods/${node.foodId}`}
+            className="inline-block rounded-full border border-emerald-200 bg-white px-3 py-1 text-sm text-emerald-700 hover:bg-emerald-50 hover:text-emerald-900"
+          >
+            {node.label}
+          </Link>
+        </li>
+      ))}
+      {rest > 0 && (
+        <li className="self-center text-xs text-gray-500">
+          {messages['and {count} more'].replace('{count}', String(rest))}
+        </li>
+      )}
+    </ul>
+  );
+}
+
+/**
+ * 食品詳細ページ用の局所半順序ビュー。この食材を支配する食材／
+ * この食材が支配する食材だけを見せる（フル Hasse 図は compare へ）。
+ * 軸は compare ページのデフォルトと同じ（可食部100gあたり）。
+ */
+export default function FoodDominationCard({
+  food,
+  foods,
+  messages,
+  locale,
+}: {
+  food: FoodToOptimize;
+  foods: FoodToOptimize[];
+  messages: Message;
+  locale: Locale;
+}) {
+  const self = toCompareNode(food, 'per100g', locale);
+  if (self === null) return null;
+
+  const others = foods
+    .filter((other) => other.id !== food.id)
+    .map((other) => toCompareNode(other, 'per100g', locale))
+    .filter((node): node is CompareNode => node !== null);
+
+  const nutrientKeys = DEFAULT_COMPARE_NUTRIENT_KEYS;
+  const dominators = others.filter((other) =>
+    dominates(other, self, nutrientKeys)
+  );
+  const dominated = others.filter((other) =>
+    dominates(self, other, nutrientKeys)
+  );
+  const incomparableCount =
+    others.length - dominators.length - dominated.length;
+
+  return (
+    <Card className="p-6 backdrop-blur-sm bg-white/70 rounded-xl shadow-lg">
+      <div className="flex flex-wrap items-center gap-3 mb-2">
+        <h2 className="text-2xl font-bold text-emerald-800">
+          {messages['Position in the cost-nutrition trade-off']}
+        </h2>
+        {dominators.length === 0 && (
+          <span className="rounded-full bg-emerald-100 px-3 py-1 text-xs font-medium text-emerald-800">
+            {messages['On the Pareto front (not dominated by any food)']}
+          </span>
+        )}
+      </div>
+      <p className="text-xs text-gray-500 mb-4">
+        {messages['domination axes note']}
+      </p>
+
+      {/* この食材の近傍だけの局所 Hasse 図（関係がある場合のみ） */}
+      {dominators.length + dominated.length > 0 && (
+        <div className="mb-6">
+          <HasseDiagram
+            nodes={[...dominators, self, ...dominated]}
+            nutrientKeys={nutrientKeys}
+            highlightedIds={[self.id]}
+            locale={locale}
+            messages={messages}
+            showHighlightCount={false}
+          />
+        </div>
+      )}
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <div>
+          <h3 className="text-sm font-semibold text-emerald-700 mb-2">
+            {messages['Foods that dominate this food']}
+          </h3>
+          <NodeList nodes={dominators} locale={locale} messages={messages} />
+        </div>
+        <div>
+          <h3 className="text-sm font-semibold text-emerald-700 mb-2">
+            {messages['Foods this food dominates']}
+          </h3>
+          <NodeList nodes={dominated} locale={locale} messages={messages} />
+        </div>
+      </div>
+
+      <div className="mt-4 flex flex-wrap items-center justify-between gap-2 border-t border-emerald-100 pt-3">
+        <p className="text-xs text-gray-500">
+          {messages['Incomparable with {count} foods (trade-off relations)'].replace(
+            '{count}',
+            String(incomparableCount)
+          )}
+        </p>
+        <Link
+          href={`/${locale}/compare?highlight=${encodeURIComponent(food.id)}`}
+          className="text-sm font-medium text-emerald-700 underline hover:text-emerald-900"
+        >
+          {messages['See in the full Hasse diagram']} →
+        </Link>
+      </div>
+    </Card>
+  );
+}

--- a/src/components/hasse-diagram.tsx
+++ b/src/components/hasse-diagram.tsx
@@ -1,0 +1,206 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useMemo } from 'react';
+
+import type { Locale } from '@/config';
+import type { Message } from '@/locales';
+import type { NutrientKey } from '@/services/diagnose';
+import { hasseEdges, skyline } from '@/services/domination';
+import type { CompareNode } from '@/services/environment';
+
+/** Hasse 図の層。支配する側が上（層0 = どこからも支配されない）。 */
+const computeLayers = (
+  nodes: CompareNode[],
+  edges: { from: string; to: string }[]
+): Map<string, number> => {
+  const parents = new Map<string, string[]>();
+  edges.forEach(({ from, to }) =>
+    parents.set(to, [...(parents.get(to) ?? []), from])
+  );
+  const memo = new Map<string, number>();
+  const layerOf = (id: string): number => {
+    const cached = memo.get(id);
+    if (cached !== undefined) return cached;
+    const dominators = parents.get(id) ?? [];
+    const layer =
+      dominators.length === 0 ? 0 : 1 + Math.max(...dominators.map(layerOf));
+    memo.set(id, layer);
+    return layer;
+  };
+  nodes.forEach((node) => layerOf(node.id));
+  return memo;
+};
+
+export const truncate = (text: string, length: number): string =>
+  text.length > length ? `${text.slice(0, length)}…` : text;
+
+const NODE_WIDTH = 128;
+const NODE_HEIGHT = 34;
+const LAYER_GAP = 110;
+const COLUMN_GAP = 12;
+
+/**
+ * コストベクトル上の半順序の Hasse 図。上ほど優位（支配する側）。
+ * ノードクリックで食品詳細ページへ遷移する。
+ * highlightedIds はサーバーコンポーネントからも渡せるよう配列で受ける。
+ */
+export const HasseDiagram = ({
+  nodes,
+  nutrientKeys,
+  highlightedIds,
+  locale,
+  messages,
+  showHighlightCount = true,
+}: {
+  nodes: CompareNode[];
+  nutrientKeys: NutrientKey[];
+  highlightedIds: readonly string[];
+  locale: Locale;
+  messages: Message;
+  /** 局所ビュー（食品詳細）では「ハイライト中: n 食材」の凡例が冗長なため消せる */
+  showHighlightCount?: boolean;
+}) => {
+  const router = useRouter();
+  const highlighted = useMemo(() => new Set(highlightedIds), [highlightedIds]);
+  const edges = useMemo(
+    () => hasseEdges(nodes, nutrientKeys),
+    [nodes, nutrientKeys]
+  );
+  const front = useMemo(
+    () => new Set(skyline(nodes, nutrientKeys).map((n) => n.id)),
+    [nodes, nutrientKeys]
+  );
+  const layers = useMemo(() => computeLayers(nodes, edges), [nodes, edges]);
+
+  const nodesByLayer = useMemo(() => {
+    const grouped = new Map<number, CompareNode[]>();
+    nodes.forEach((node) => {
+      const layer = layers.get(node.id) ?? 0;
+      grouped.set(layer, [...(grouped.get(layer) ?? []), node]);
+    });
+    return grouped;
+  }, [nodes, layers]);
+
+  const positions = useMemo(
+    () =>
+      new Map(
+        [...nodesByLayer.entries()].flatMap(([layer, layerNodes]) =>
+          layerNodes.map((node, index) => [
+            node.id,
+            {
+              x: index * (NODE_WIDTH + COLUMN_GAP) + NODE_WIDTH / 2,
+              y: layer * LAYER_GAP + NODE_HEIGHT / 2 + 10,
+            },
+          ])
+        )
+      ),
+    [nodesByLayer]
+  );
+
+  const width =
+    Math.max(...[...nodesByLayer.values()].map((ns) => ns.length)) *
+    (NODE_WIDTH + COLUMN_GAP);
+  const height = (Math.max(...[...layers.values()], 0) + 1) * LAYER_GAP + 20;
+
+  const tooltip = (node: CompareNode): string =>
+    [
+      node.label,
+      `${messages['intake form']}: ${messages[node.intakeForm]} / ${messages.distribution}: ${messages.retail} / ${node.productionMethod === 'organic' ? messages.organic : messages.conventional}`,
+      ...nutrientKeys.map(
+        (key) => `${messages[key]}: ${node.nutrientDensity[key].toPrecision(3)}`
+      ),
+      `${messages.yen}: ${node.costVector.yen.toPrecision(3)}`,
+      `CO2e: ${node.costVector.co2eKg.toPrecision(3)} kg`,
+      `${messages.land}: ${node.costVector.landM2.toPrecision(3)} m²`,
+      `${messages.water}: ${node.costVector.waterL.toPrecision(3)} L`,
+      ...(node.pesticideResidue
+        ? [
+            messages[
+              'pesticide residue: present (health impact not assessed)'
+            ],
+          ]
+        : []),
+    ].join('\n');
+
+  const highlightedCount = nodes.filter((node) =>
+    highlighted.has(node.id)
+  ).length;
+
+  return (
+    <div className="overflow-x-auto">
+      <p className="mb-2 text-xs text-gray-500">
+        {messages['hasse orientation note']}
+      </p>
+      {showHighlightCount && highlightedCount > 0 && (
+        <p className="mb-2 text-xs font-medium text-amber-700">
+          {messages['Highlighting {count} foods'].replace(
+            '{count}',
+            String(highlightedCount)
+          )}
+        </p>
+      )}
+      <svg width={width} height={height} className="min-w-full">
+        {edges.map(({ from, to }) => {
+          const a = positions.get(from);
+          const b = positions.get(to);
+          if (!a || !b) return null;
+          return (
+            <line
+              key={`${from}-${to}`}
+              x1={a.x}
+              y1={a.y + NODE_HEIGHT / 2}
+              x2={b.x}
+              y2={b.y - NODE_HEIGHT / 2}
+              stroke="#94a3b8"
+              strokeWidth={1}
+            />
+          );
+        })}
+        {nodes.map((node) => {
+          const position = positions.get(node.id);
+          if (!position) return null;
+          const organic = node.productionMethod === 'organic';
+          const dominated = !front.has(node.id);
+          const isHighlighted = highlighted.has(node.id);
+          return (
+            <g
+              key={node.id}
+              transform={`translate(${position.x - NODE_WIDTH / 2}, ${position.y - NODE_HEIGHT / 2})`}
+              // 支配されたノード（有機を含む）も隠さず、薄くして表示する。
+              // ハイライト対象は導線元（リコメンド等）の注目ノードなので薄くしない。
+              opacity={dominated && !isHighlighted ? 0.55 : 1}
+              className="cursor-pointer"
+              onClick={() => router.push(`/${locale}/foods/${node.foodId}`)}
+            >
+              <title>{tooltip(node)}</title>
+              <rect
+                width={NODE_WIDTH}
+                height={NODE_HEIGHT}
+                rx={6}
+                fill={
+                  organic ? '#dcfce7' : isHighlighted ? '#fffbeb' : '#ffffff'
+                }
+                stroke={
+                  isHighlighted ? '#f59e0b' : organic ? '#16a34a' : '#64748b'
+                }
+                strokeWidth={isHighlighted ? 3 : front.has(node.id) ? 2 : 1}
+              />
+              <text x={6} y={14} fontSize={10} fill="#0f172a">
+                {truncate(node.label, 12)}
+                {organic ? ' 🌱' : ''}
+              </text>
+              <text x={6} y={27} fontSize={9} fill="#475569">
+                {messages[node.intakeForm]}
+                {dominated ? ` / ${messages.dominated}` : ''}
+                {node.pesticideResidue
+                  ? ` / ${messages['pesticide residue (not assessed)']}`
+                  : ''}
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+    </div>
+  );
+};

--- a/src/components/site-nav.tsx
+++ b/src/components/site-nav.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import {
+  PROFILE_STORAGE_KEY,
+  type Locale,
+  type StoredProfile,
+} from '@/config';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+const isStoredProfile = (value: unknown): value is StoredProfile =>
+  typeof value === 'object' &&
+  value !== null &&
+  (['sex', 'age', 'weight', 'pal', 'status'] as const).every(
+    (key) => typeof (value as Record<string, unknown>)[key] === 'string'
+  );
+
+const readProfile = (): StoredProfile | null => {
+  try {
+    const raw = localStorage.getItem(PROFILE_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    return isStoredProfile(parsed) ? parsed : null;
+  } catch {
+    // プライベートモード等で localStorage が使えない場合は未保存扱い
+    return null;
+  }
+};
+
+export type SiteNavLabels = {
+  recommendations: string;
+  foods: string;
+  compare: string;
+};
+
+/**
+ * 共通ヘッダーナビ。「おすすめ献立」は保存済みプロフィールがあれば
+ * 前回のリコメンドページへ、なければトップのフォームへ飛ぶ。
+ */
+export function SiteNav({
+  locale,
+  labels,
+}: {
+  locale: Locale;
+  labels: SiteNavLabels;
+}) {
+  const pathname = usePathname();
+  // localStorage は SSG の HTML と一致しないため、マウント後に読む。
+  // フォーム送信直後の SPA 遷移でも反映されるよう、ルート変更ごとに再読する。
+  const [profile, setProfile] = useState<StoredProfile | null>(null);
+  useEffect(() => setProfile(readProfile()), [pathname]);
+
+  const recommendationsHref = profile
+    ? `/${locale}/recommendations/${profile.sex}/${profile.age}/${profile.weight}/${profile.pal}/${profile.status}`
+    : `/${locale}`;
+
+  const items = [
+    {
+      href: recommendationsHref,
+      label: labels.recommendations,
+      active:
+        pathname === `/${locale}` ||
+        pathname.startsWith(`/${locale}/recommendations`),
+    },
+    {
+      href: `/${locale}/foods`,
+      label: labels.foods,
+      active: pathname.startsWith(`/${locale}/foods`),
+    },
+    {
+      href: `/${locale}/compare`,
+      label: labels.compare,
+      active: pathname.startsWith(`/${locale}/compare`),
+    },
+  ];
+
+  return (
+    <nav className="flex items-center gap-1">
+      {items.map((item) => (
+        <Link
+          key={item.label}
+          href={item.href}
+          className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors whitespace-nowrap ${
+            item.active
+              ? 'bg-emerald-100 text-emerald-900'
+              : 'text-emerald-700 hover:bg-emerald-50'
+          }`}
+        >
+          {item.label}
+        </Link>
+      ))}
+    </nav>
+  );
+}

--- a/src/components/top-page.tsx
+++ b/src/components/top-page.tsx
@@ -1,4 +1,3 @@
-import Link from 'next/link';
 import { Locale } from '@/config';
 import { Leaf } from 'lucide-react';
 
@@ -35,14 +34,6 @@ export function TopPage({
         {/* Card Content / Form */}
         <div className="px-6 pb-8">
           <UserInfoForm locale={locale} />
-          <p className="mt-6 text-center">
-            <Link
-              href={`/${locale}/compare`}
-              className="text-sm text-emerald-700 underline hover:text-emerald-900"
-            >
-              {messages['Compare foods for wallet and environment']} →
-            </Link>
-          </p>
         </div>
       </div>
     </div>

--- a/src/components/user-info-form.tsx
+++ b/src/components/user-info-form.tsx
@@ -8,7 +8,9 @@ import {
   isChildSegment,
   palCategoriesFor,
   statusesFor,
+  PROFILE_STORAGE_KEY,
   type StatusSegment,
+  type StoredProfile,
 } from '@/config';
 import { type Sex } from '@/data';
 import { enUS, jaJP } from '@/locales';
@@ -50,6 +52,19 @@ export default function UserInfoForm({ locale }: { locale: Locale }) {
     const pal = palOptions.length === 1 ? palOptions[0] : form.pal.value;
     // 小児は参照体重を用いるため体重入力を使わず、静的生成と同じトークンを送る。
     const weight = isChild ? CHILD_WEIGHT_SEGMENT : form.weight.value;
+    // ナビの「おすすめ献立」が前回のページへ直接飛べるよう保存する
+    try {
+      const profile: StoredProfile = {
+        sex: sex as StoredProfile['sex'],
+        age,
+        weight,
+        pal,
+        status: effectiveStatus,
+      };
+      localStorage.setItem(PROFILE_STORAGE_KEY, JSON.stringify(profile));
+    } catch {
+      // localStorage が使えない環境では保存を諦める
+    }
     router.push(
       `/${locale}/recommendations/${sex}/${age}/${weight}/${pal}/${effectiveStatus}`
     );

--- a/src/config.ts
+++ b/src/config.ts
@@ -105,3 +105,18 @@ export const statusesFor = (
 // next/image with `unoptimized` does not prepend basePath, so public
 // assets referenced by absolute path must include it themselves.
 export const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+
+/**
+ * フォーム入力（リコメンド URL のセグメント）の localStorage 保存先。
+ * ナビの「おすすめ献立」が前回のプロフィールのページへ直接飛ぶために参照する。
+ */
+export const PROFILE_STORAGE_KEY = 'nutrition-optimizer.profile';
+
+/** 保存するプロフィール。値はすべて URL セグメントの文字列。 */
+export type StoredProfile = {
+  sex: Sex;
+  age: string;
+  weight: string;
+  pal: PalCategory;
+  status: StatusSegment;
+};

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -149,5 +149,20 @@
   "raw": "raw",
   "as is": "as is",
   "compare page description": "Only foods that are denser on every selected nutrient axis and lower on every cost axis (yen, CO2e, land, water) \"dominate\". Pairs without an arrow (e.g. organic vs conventional) are incomparable.",
-  "compare methodology note": "Environmental impact figures are world averages by food category from Poore & Nemecek (2018); differences by origin are not corrected. Cost is a vector of (yen, CO2e, land, water), and the Pareto view keeps incomparable pairs. Health effects of pesticide residues are not quantified and are treated as \"not assessed\"."
+  "compare methodology note": "Environmental impact figures are world averages by food category from Poore & Nemecek (2018); differences by origin are not corrected. Cost is a vector of (yen, CO2e, land, water), and the Pareto view keeps incomparable pairs. Health effects of pesticide residues are not quantified and are treated as \"not assessed\".",
+  "My plan": "My plan",
+  "Food database": "Food database",
+  "Compare": "Compare",
+  "Why these foods? See the rationale on the Hasse diagram": "Why these foods? See the rationale in the Pareto comparison (Hasse diagram)",
+  "Position in the cost-nutrition trade-off": "Position in the cost–nutrition trade-off",
+  "Foods that dominate this food": "Foods that dominate this food",
+  "Foods this food dominates": "Foods this food dominates",
+  "On the Pareto front (not dominated by any food)": "On the Pareto front (not dominated by any food)",
+  "Incomparable with {count} foods (trade-off relations)": "Incomparable with {count} foods (trade-off relations)",
+  "domination axes note": "Axes: nutrient density per 100 g (protein, fiber, vitamin C) × cost (yen, CO2e, land, water). Domination = at least as good on every axis and strictly better on at least one.",
+  "See in the full Hasse diagram": "See in the full Hasse diagram",
+  "Highlighting {count} foods": "Highlighting {count} foods",
+  "(none)": "(none)",
+  "hasse orientation note": "Higher is better. A line means the upper food dominates the lower one (at least as good on every axis, strictly better on at least one); pairs with no line are incomparable. Click a node to open the food's detail page.",
+  "and {count} more": "and {count} more"
 }

--- a/src/locales/ja-JP.json
+++ b/src/locales/ja-JP.json
@@ -149,5 +149,20 @@
   "raw": "生",
   "as is": "そのまま",
   "compare page description": "選んだ栄養軸すべてで密度が高く、全コスト軸（円・CO2e・土地・水）で負荷が低い食材だけが「支配する」。矢印のない組（有機 vs 慣行など）は比較不能。",
-  "compare methodology note": "環境負荷は Poore & Nemecek (2018) の食材カテゴリ別世界平均値で、原産地差は未補正。コストは (円, CO2e, 土地, 水) のベクトルで、Pareto 表示では比較不能な組を保持する。残留農薬の健康影響は数値化せず「未評価」として扱う。"
+  "compare methodology note": "環境負荷は Poore & Nemecek (2018) の食材カテゴリ別世界平均値で、原産地差は未補正。コストは (円, CO2e, 土地, 水) のベクトルで、Pareto 表示では比較不能な組を保持する。残留農薬の健康影響は数値化せず「未評価」として扱う。",
+  "My plan": "おすすめ献立",
+  "Food database": "食品DB",
+  "Compare": "比較",
+  "Why these foods? See the rationale on the Hasse diagram": "なぜこの食材？根拠を Pareto 比較（Hasse図）で見る",
+  "Position in the cost-nutrition trade-off": "コスト・栄養トレードオフ上の位置",
+  "Foods that dominate this food": "この食材を支配する食材",
+  "Foods this food dominates": "この食材が支配する食材",
+  "On the Pareto front (not dominated by any food)": "Pareto フロント上（どの食材にも支配されない）",
+  "Incomparable with {count} foods (trade-off relations)": "{count} 食材とは比較不能（トレードオフ関係）",
+  "domination axes note": "軸: 可食部100gあたりの栄養密度（たんぱく質・食物繊維・ビタミンC）× コスト（円・CO2e・土地・水）。支配 = 全軸で同等以上かつ少なくとも1軸で厳密に良い。",
+  "See in the full Hasse diagram": "Hasse 図全体で見る",
+  "Highlighting {count} foods": "ハイライト中: {count} 食材",
+  "(none)": "なし",
+  "hasse orientation note": "上にある食材ほど優位。線は「上の食材が下の食材を支配する（全軸で同等以上・少なくとも1軸で厳密に良い）」ことを表し、線で結ばれていない組は比較不能。ノードをクリックすると食品詳細へ。",
+  "and {count} more": "ほか {count} 件"
 }

--- a/src/services/domination.ts
+++ b/src/services/domination.ts
@@ -15,6 +15,16 @@ import type { CompareNode, CostVector } from '@/services/environment';
 export const COST_AXES = ['yen', 'co2eKg', 'landM2', 'waterL'] as const;
 export type CostAxis = (typeof COST_AXES)[number];
 
+/**
+ * 比較 UI のデフォルト栄養軸。compare ページの初期選択と、
+ * 食品詳細ページの局所支配関係ビューで共有する。
+ */
+export const DEFAULT_COMPARE_NUTRIENT_KEYS: NutrientKey[] = [
+  'protein',
+  'fiber',
+  'vitaminC',
+];
+
 export const dominates = (
   x: CompareNode,
   y: CompareNode,


### PR DESCRIPTION
## Summary

3つの独立したページ（リコメンド / 食品DB / 比較）を「答え → 根拠 → 探索」のハブ&スポーク構造でつなぐ。

- **共通ヘッダーナビ**（おすすめ献立 / 食品DB / 比較）を `[locale]/layout.tsx` に追加。フォーム入力を localStorage に保存し、「おすすめ献立」は前回のプロフィールのリコメンドページへ直接遷移（未入力ならトップへ）
- **リコメンド → 比較の導線**: 「なぜこの食材？」リンクで選ばれた食材を `?highlight=id1,id2` として渡し、Hasse図・スカラー化ランキング上でアンバー強調
- **HasseDiagram を独立コンポーネント化** (`hasse-diagram.tsx`)
  - 図の直上に「上にある食材ほど優位」の注記（ja/en）
  - ノードクリックで食品詳細ページへ遷移
- **食品詳細ページに局所半順序カード** (`food-domination-card.tsx`): 支配する食材 / 支配される食材のミニHasse図とリンク、Paretoフロントバッジ、比較不能数、フルHasse図への導線。軸は比較ページのデフォルトと同じ `DEFAULT_COMPARE_NUTRIENT_KEYS`（たんぱく質・食物繊維・ビタミンC）
- トップページの比較リンクはナビへ移動

## Test plan

- [x] `tsc --noEmit` / `eslint` / `vitest` 46件 パス
- [x] ブラウザでナビ・highlight・局所Hasse図・ノードクリック遷移を確認
- [x] `pnpm build`（静的エクスポート 1803ページ）成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)