### PR TITLE
fix: show all form inputs in recommendation page header

### DIFF
--- a/src/app/[locale]/recommendations/[sex]/[age]/[weight]/[pal_category]/[status]/page.tsx
+++ b/src/app/[locale]/recommendations/[sex]/[age]/[weight]/[pal_category]/[status]/page.tsx
@@ -13,6 +13,7 @@ import {
   isChildSegment,
   palCategoriesFor,
   statusesFor,
+  STATUS_LABEL_KEY,
   type StatusSegment,
 } from '@/config';
 import type { Locale } from '@/config';
@@ -113,8 +114,19 @@ export default async function RecommendationPage({
                 'This is the result of calculation of your diet for cost and nutrition'
               ]
             }
-            : {messages[params.sex]}, {messages['physical activity level']}{' '}
-            {messages[params.pal_category]}
+            : {messages[params.sex]}, {messages['age']}{' '}
+            {ageBand.replace('-', '–')}
+            {/* 小児は体重・PAL を入力しないため、フォームに現れた項目だけを示す */}
+            {!isChildSegment(params.age) && <>, {weightKg} kg</>}
+            {palCategoriesFor(params.age).length > 1 && (
+              <>
+                , {messages['physical activity level']}{' '}
+                {messages[params.pal_category]}
+              </>
+            )}
+            {params.status !== 'none' && (
+              <>, {messages[STATUS_LABEL_KEY[params.status]]}</>
+            )}
           </p>
         </header>
 

--- a/src/components/user-info-form.tsx
+++ b/src/components/user-info-form.tsx
@@ -9,6 +9,7 @@ import {
   palCategoriesFor,
   statusesFor,
   PROFILE_STORAGE_KEY,
+  STATUS_LABEL_KEY,
   type StatusSegment,
   type StoredProfile,
 } from '@/config';
@@ -17,15 +18,6 @@ import { enUS, jaJP } from '@/locales';
 import { capitalize, toTitleCase } from '@/utils';
 import { useRouter } from 'next/navigation';
 import { useMemo, useState } from 'react';
-
-const STATUS_LABEL_KEY: Record<StatusSegment, keyof typeof enUS> = {
-  none: 'not menstruating or pregnant',
-  menstruation: 'menstruating',
-  'pregnancy-early': 'pregnancy (first trimester)',
-  'pregnancy-mid': 'pregnancy (second trimester)',
-  'pregnancy-late': 'pregnancy (third trimester)',
-  lactation: 'lactating',
-};
 
 export default function UserInfoForm({ locale }: { locale: Locale }) {
   const router = useRouter();

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,5 @@
 import type { AgeBand, PalCategory, Sex } from '@/data';
+import type { Message } from '@/locales';
 
 export type Locale = 'en-US' | 'ja-JP';
 
@@ -68,6 +69,19 @@ export type StatusSegment =
   | 'pregnancy-mid'
   | 'pregnancy-late'
   | 'lactation';
+
+/**
+ * [status] セグメントの表示ラベルのメッセージキー。
+ * フォームの選択肢とリコメンドページの対象説明の両方が参照する。
+ */
+export const STATUS_LABEL_KEY: Record<StatusSegment, keyof Message> = {
+  none: 'not menstruating or pregnant',
+  menstruation: 'menstruating',
+  'pregnancy-early': 'pregnancy (first trimester)',
+  'pregnancy-mid': 'pregnancy (second trimester)',
+  'pregnancy-late': 'pregnancy (third trimester)',
+  lactation: 'lactating',
+};
 
 /** 月経ありを選べる年齢帯（鉄に月経あり列がある区分）。 */
 const MENSTRUATION_BANDS: ReadonlySet<AgeBand> = new Set<AgeBand>([

--- a/src/locales/ja-JP.json
+++ b/src/locales/ja-JP.json
@@ -1,7 +1,7 @@
 {
   "Vegan Food Planner": "ヴィーガン食事プランナー",
   "Recommendations": "栄養最適化の結果",
-  "This is the result of calculation of your diet for cost and nutrition": "栄養バランスを最適化し、コストを最小限に抑えた食材の組み合わせです。対象:",
+  "This is the result of calculation of your diet for cost and nutrition": "栄養バランスを最適化し、コストを最小限に抑えた食材の組み合わせです。対象",
   "male": "男性",
   "female": "女性",
   "physical activity level": "身体活動レベル",


### PR DESCRIPTION
## Summary

The target description on the recommendation page header only showed sex and physical activity level, even though the form (and the URL path parameters) also carry age band, body weight, and reproductive status. It also rendered a doubled colon in Japanese ("対象:: 男性") because both the ja-JP locale message and the JSX appended a colon.

- Include age band, weight, PAL, and status in the header, mirroring the form's visibility rules: children show no weight/PAL (not entered in the form), and status appears only when it is not "none"
- Move `STATUS_LABEL_KEY` from `user-info-form.tsx` to `config.ts` so the form and the recommendation page share the same status labels
- Drop the trailing colon from the ja-JP description message to fix the doubled colon

## Verification

- `tsc --noEmit` and `vitest run` (51 tests) pass
- Checked rendering in the browser for four cases:
  - `/ja-JP/recommendations/male/30/60/normal/none` → 「対象: 男性, 年齢 30–49, 60 kg, 身体活動レベル 普通」
  - `/ja-JP/recommendations/female/18/50/low/menstruation` → 「…, 月経あり（鉄の必要量が上がります）」
  - `/ja-JP/recommendations/male/3/ref/normal/none` → 「対象: 男性, 年齢 3–5」(no weight/PAL, same as the form)
  - `/en-US/recommendations/female/30/55/high/lactation` → "…: female, age 30–49, 55 kg, physical activity level high, lactating"

🤖 Generated with [Claude Code](https://claude.com/claude-code)