### PR TITLE
feat: keep profile in sessionStorage instead of localStorage

### DIFF
--- a/src/components/site-nav.tsx
+++ b/src/components/site-nav.tsx
@@ -24,7 +24,7 @@ export function SiteNav({
   labels: SiteNavLabels;
 }) {
   const pathname = usePathname();
-  // localStorage は SSG の HTML と一致しないため、マウント後に読む。
+  // sessionStorage は SSG の HTML と一致しないため、マウント後に読む。
   // フォーム送信直後の SPA 遷移でも反映されるよう、ルート変更ごとに再読する。
   const [profile, setProfile] = useState<StoredProfile | null>(null);
   useEffect(() => setProfile(readStoredProfile()), [pathname]);

--- a/src/components/user-info-form.tsx
+++ b/src/components/user-info-form.tsx
@@ -37,7 +37,7 @@ export default function UserInfoForm({ locale }: { locale: Locale }) {
   // 「ふつう」が代表値のため既定選択にし、多くの人は触らず送信できるようにする
   const [pal, setPal] = useState<PalCategory>('normal');
 
-  // 前回のプロフィールを初期値に復元する。localStorage は SSG の HTML と
+  // 前回のプロフィールを初期値に復元する。sessionStorage は SSG の HTML と
   // 一致しないため、マウント後に読む。値は選択肢に残っているものだけ採用する。
   useEffect(() => {
     const profile = readStoredProfile();

--- a/src/config.ts
+++ b/src/config.ts
@@ -121,7 +121,7 @@ export const statusesFor = (
 export const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
 
 /**
- * フォーム入力（リコメンド URL のセグメント）の localStorage 保存先。
+ * フォーム入力（リコメンド URL のセグメント）の sessionStorage 保存先。
  * ナビの「おすすめ献立」が前回のプロフィールのページへ直接飛ぶために参照する。
  */
 export const PROFILE_STORAGE_KEY = 'nutrition-optimizer.profile';

--- a/src/lib/profile-storage.ts
+++ b/src/lib/profile-storage.ts
@@ -7,22 +7,28 @@ const isStoredProfile = (value: unknown): value is StoredProfile =>
     (key) => typeof (value as Record<string, unknown>)[key] === 'string'
   );
 
+// 妊娠状態を含むためブラウザを閉じたら消える sessionStorage を使う。
+// 共用PCで前回のプロフィールが無期限に残らないようにするための選択で、
+// localStorage に戻さないこと。
 export const readStoredProfile = (): StoredProfile | null => {
   try {
-    const raw = localStorage.getItem(PROFILE_STORAGE_KEY);
+    // 以前は localStorage に保存していた。残っていると無期限に持ち続けて
+    // しまうため、読み出しのついでに旧データを消す。
+    localStorage.removeItem(PROFILE_STORAGE_KEY);
+    const raw = sessionStorage.getItem(PROFILE_STORAGE_KEY);
     if (!raw) return null;
     const parsed: unknown = JSON.parse(raw);
     return isStoredProfile(parsed) ? parsed : null;
   } catch {
-    // プライベートモード等で localStorage が使えない場合は未保存扱い
+    // プライベートモード等で sessionStorage が使えない場合は未保存扱い
     return null;
   }
 };
 
 export const writeStoredProfile = (profile: StoredProfile): void => {
   try {
-    localStorage.setItem(PROFILE_STORAGE_KEY, JSON.stringify(profile));
+    sessionStorage.setItem(PROFILE_STORAGE_KEY, JSON.stringify(profile));
   } catch {
-    // localStorage が使えない環境では保存を諦める
+    // sessionStorage が使えない環境では保存を諦める
   }
 };


### PR DESCRIPTION
## Summary

The stored profile includes pregnancy status, so persisting it indefinitely (localStorage has no expiry) is undesirable on shared machines. This switches `src/lib/profile-storage.ts` to sessionStorage:

- Within a visit nothing changes: the nav "おすすめ献立" shortcut and the form-default restore from #34 keep working.
- Closing the tab clears the profile.
- Legacy localStorage entries from before this change are purged on first read, so existing visitors don't keep stale data around.
- Comments referencing localStorage updated (config.ts, site-nav.tsx, user-info-form.tsx).

## Test plan

- `pnpm test` (51 passed), `pnpm lint`, `tsc --noEmit` all green
- Verified in dev server with a legacy localStorage profile present: it is removed on page load, the form starts clean, and submitting writes to sessionStorage only (localStorage stays empty) while navigating to the correct recommendations URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)