### PR TITLE
feat: 比較ページの選択状態（基準・軸・ビュー）をURLに同期して共有可能に

### DIFF
--- a/src/components/food-comparison.tsx
+++ b/src/components/food-comparison.tsx
@@ -1,12 +1,26 @@
 'use client';
 
 import Link from 'next/link';
-import { useSearchParams } from 'next/navigation';
+import { usePathname, useSearchParams } from 'next/navigation';
 import { useEffect, useMemo, useState } from 'react';
 
 import { HasseDiagram, truncate } from '@/components/hasse-diagram';
 import { Card, CardContent } from '@/components/ui/card';
 import type { Locale } from '@/config';
+import {
+  MAX_AXES,
+  MIN_AXES,
+  NUTRIENT_KEYS,
+  defaultAxesFor,
+  denominatorCostOf,
+  denominatorNutrientOf,
+  parseAxes,
+  parseBasis,
+  parseView,
+  sameAxes,
+  serializeAxes,
+  type CompareView,
+} from '@/lib/compare-state';
 import {
   ZERO_WEIGHTS,
   hasNonZeroWeights,
@@ -17,7 +31,6 @@ import type { Message } from '@/locales';
 import type { NutrientKey } from '@/services/diagnose';
 import {
   COST_AXES,
-  DEFAULT_COMPARE_AXES,
   scalarizeCost,
   skyline,
   type ComparisonAxes,
@@ -28,59 +41,11 @@ import { toCompareNode, type CompareNode } from '@/services/environment';
 import type { Basis } from '@/services/nutrient-density';
 import type { FoodToOptimize } from '@/types/nutrition';
 
-const NUTRIENT_KEYS: NutrientKey[] = [
-  'calories',
-  'protein',
-  'fat',
-  'saturatedFattyAcids',
-  'n6PolyunsaturatedFattyAcids',
-  'n3PolyunsaturatedFattyAcids',
-  'carbohydrates',
-  'fiber',
-  'vitaminA',
-  'vitaminD',
-  'vitaminE',
-  'vitaminK',
-  'vitaminB1',
-  'vitaminB2',
-  'vitaminB6',
-  'vitaminB12',
-  'niacin',
-  'folate',
-  'pantothenicAcid',
-  'biotin',
-  'vitaminC',
-  'nacl',
-  'potassium',
-  'calcium',
-  'magnesium',
-  'phosphorus',
-  'iron',
-  'zinc',
-  'copper',
-  'manganese',
-  'iodine',
-  'selenium',
-  'chromium',
-  'molybdenum',
-];
-
-// 軸は栄養+コスト合計で 2〜5 個。高次元では比較可能対が 2^{1-d} で消えて
-// ほぼ全ノードが antichain 化するため（domination.test.ts で確認済み）。
-const MIN_AXES = 2;
-const MAX_AXES = 5;
-
 const BASIS_LABELS: Record<Basis, keyof Message> = {
   per100g: 'per 100 g edible portion',
   perYen: 'per 1 yen',
   perKcal: 'per 1 kcal',
 };
-
-// 基準の分母に使っている量は全ノードで定数になるため、軸から外す
-const denominatorNutrientOf = (basis: Basis): NutrientKey | null =>
-  basis === 'perKcal' ? 'calories' : null;
-const denominatorCostOf = (basis: Basis): CostAxis | null =>
-  basis === 'perYen' ? 'yen' : null;
 
 const costAxisLabels = (messages: Message): Record<CostAxis, string> => ({
   yen: messages.price,
@@ -296,6 +261,7 @@ export default function FoodComparison({
   messages: Message;
   locale: Locale;
 }) {
+  const pathname = usePathname();
   const searchParams = useSearchParams();
   // 導線元（リコメンド・食品詳細）から ?highlight=id1,id2 で注目食材を受け取る
   const highlightedIds = useMemo(
@@ -304,9 +270,38 @@ export default function FoodComparison({
     [searchParams]
   );
 
-  const [basis, setBasis] = useState<Basis>('per100g');
-  const [mode, setMode] = useState<'graph' | 'table'>('graph');
-  const [axes, setAxes] = useState<ComparisonAxes>(DEFAULT_COMPARE_AXES);
+  // 選択状態（基準・軸・ビュー）は URL クエリを単一の情報源にする。
+  // 見えている比較をそのまま共有でき、リロードや戻るボタンでも保たれる。
+  // 既定値のパラメータは URL から省く。
+  const basis = parseBasis(searchParams.get('basis'));
+  const view = parseView(searchParams.get('view'));
+  const axes = useMemo(
+    () => parseAxes(searchParams.get('axes'), basis),
+    [searchParams, basis]
+  );
+
+  // ページ遷移ではないので history.replaceState で浅く書き換える
+  // （Next 14.1+ は useSearchParams に反映される）。
+  const updateQuery = (updates: Record<string, string | null>) => {
+    const params = new URLSearchParams(searchParams.toString());
+    Object.entries(updates).forEach(([key, value]) =>
+      value === null ? params.delete(key) : params.set(key, value)
+    );
+    const query = params.toString();
+    window.history.replaceState(null, '', query ? `${pathname}?${query}` : pathname);
+  };
+
+  const changeView = (next: CompareView) =>
+    updateQuery({ view: next === 'graph' ? null : next });
+
+  const applyAxes = (next: ComparisonAxes, nextBasis: Basis = basis) =>
+    updateQuery({
+      basis: nextBasis === 'per100g' ? null : nextBasis,
+      axes: sameAxes(next, defaultAxesFor(nextBasis))
+        ? null
+        : serializeAxes(next),
+    });
+
   // 環境負荷の円換算価格はおすすめ献立ページで設定し、ここでは
   // 表の総コスト列（導出値）にだけ使う。SSG と一致させるため初期値 0。
   const [weights, setWeights] =
@@ -325,42 +320,39 @@ export default function FoodComparison({
 
   const axisCount = axes.nutrientKeys.length + axes.costAxes.length;
 
-  const toggleNutrientKey = (key: NutrientKey) =>
-    setAxes((previous) => {
-      const count = previous.nutrientKeys.length + previous.costAxes.length;
-      const checked = previous.nutrientKeys.includes(key);
-      if (checked ? count <= MIN_AXES : count >= MAX_AXES) return previous;
-      return {
-        ...previous,
-        nutrientKeys: checked
-          ? previous.nutrientKeys.filter((k) => k !== key)
-          : [...previous.nutrientKeys, key],
-      };
+  const toggleNutrientKey = (key: NutrientKey) => {
+    const checked = axes.nutrientKeys.includes(key);
+    if (checked ? axisCount <= MIN_AXES : axisCount >= MAX_AXES) return;
+    applyAxes({
+      ...axes,
+      nutrientKeys: checked
+        ? axes.nutrientKeys.filter((k) => k !== key)
+        : [...axes.nutrientKeys, key],
     });
-
-  const toggleCostAxis = (axis: CostAxis) =>
-    setAxes((previous) => {
-      const count = previous.nutrientKeys.length + previous.costAxes.length;
-      const checked = previous.costAxes.includes(axis);
-      if (checked ? count <= MIN_AXES : count >= MAX_AXES) return previous;
-      return {
-        ...previous,
-        costAxes: checked
-          ? previous.costAxes.filter((a) => a !== axis)
-          : [...previous.costAxes, axis],
-      };
-    });
-
-  const changeBasis = (next: Basis) => {
-    setBasis(next);
-    // 分母に使う量は全ノードで定数になるため、選択から外す
-    setAxes((previous) => ({
-      nutrientKeys: previous.nutrientKeys.filter(
-        (k) => k !== denominatorNutrientOf(next)
-      ),
-      costAxes: previous.costAxes.filter((a) => a !== denominatorCostOf(next)),
-    }));
   };
+
+  const toggleCostAxis = (axis: CostAxis) => {
+    const checked = axes.costAxes.includes(axis);
+    if (checked ? axisCount <= MIN_AXES : axisCount >= MAX_AXES) return;
+    applyAxes({
+      ...axes,
+      costAxes: checked
+        ? axes.costAxes.filter((a) => a !== axis)
+        : [...axes.costAxes, axis],
+    });
+  };
+
+  const changeBasis = (next: Basis) =>
+    // 分母に使う量は全ノードで定数になるため、選択から外す
+    applyAxes(
+      {
+        nutrientKeys: axes.nutrientKeys.filter(
+          (k) => k !== denominatorNutrientOf(next)
+        ),
+        costAxes: axes.costAxes.filter((a) => a !== denominatorCostOf(next)),
+      },
+      next
+    );
 
   const costLabels = costAxisLabels(messages);
 
@@ -375,9 +367,9 @@ export default function FoodComparison({
               {(['graph', 'table'] as const).map((m) => (
                 <button
                   key={m}
-                  onClick={() => setMode(m)}
+                  onClick={() => changeView(m)}
                   className={`px-3 py-1 rounded-md text-sm ${
-                    mode === m
+                    view === m
                       ? 'bg-white text-emerald-800 shadow'
                       : 'text-emerald-700'
                   }`}
@@ -478,7 +470,7 @@ export default function FoodComparison({
 
       <Card className="min-w-0">
         <CardContent className="p-6">
-          {mode === 'graph' ? (
+          {view === 'graph' ? (
             <HasseDiagram
               nodes={nodes}
               axes={axes}

--- a/src/lib/compare-state.test.ts
+++ b/src/lib/compare-state.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  MAX_AXES,
+  defaultAxesFor,
+  parseAxes,
+  parseBasis,
+  parseView,
+  sameAxes,
+  serializeAxes,
+} from '@/lib/compare-state';
+import { DEFAULT_COMPARE_AXES } from '@/services/domination';
+
+describe('parseBasis / parseView', () => {
+  it('不正な値は既定値に丸める', () => {
+    expect(parseBasis(null)).toBe('per100g');
+    expect(parseBasis('perYen')).toBe('perYen');
+    expect(parseBasis('nonsense')).toBe('per100g');
+    expect(parseView(null)).toBe('graph');
+    expect(parseView('table')).toBe('table');
+    expect(parseView('list')).toBe('graph');
+  });
+});
+
+describe('parseAxes / serializeAxes', () => {
+  it('シリアライズと解釈が往復する', () => {
+    const axes = parseAxes('protein,fiber,yen,co2eKg', 'per100g');
+    expect(axes).toEqual({
+      nutrientKeys: ['protein', 'fiber'],
+      costAxes: ['yen', 'co2eKg'],
+    });
+    expect(parseAxes(serializeAxes(axes), 'per100g')).toEqual(axes);
+  });
+
+  it('未知のトークンと重複は捨てる', () => {
+    expect(parseAxes('protein,protein,unicorn,yen', 'per100g')).toEqual({
+      nutrientKeys: ['protein'],
+      costAxes: ['yen'],
+    });
+  });
+
+  it('基準の分母に使っている軸は捨てる（1円あたり→価格、1kcalあたり→カロリー）', () => {
+    expect(parseAxes('protein,yen,co2eKg', 'perYen').costAxes).toEqual([
+      'co2eKg',
+    ]);
+    expect(parseAxes('calories,protein,yen', 'perKcal').nutrientKeys).toEqual([
+      'protein',
+    ]);
+  });
+
+  it('空・全滅なら基準に応じた既定値へ', () => {
+    expect(parseAxes(null, 'per100g')).toEqual(DEFAULT_COMPARE_AXES);
+    expect(parseAxes('', 'per100g')).toEqual(DEFAULT_COMPARE_AXES);
+    expect(parseAxes('unicorn', 'per100g')).toEqual(DEFAULT_COMPARE_AXES);
+    // perYen の既定は価格を含まない
+    expect(defaultAxesFor('perYen').costAxes).toEqual(['co2eKg']);
+    expect(parseAxes('yen', 'perYen')).toEqual(defaultAxesFor('perYen'));
+  });
+
+  it('MAX_AXES 個で打ち切る', () => {
+    const many = 'protein,fiber,vitaminC,iron,calcium,zinc,yen';
+    const axes = parseAxes(many, 'per100g');
+    expect(axes.nutrientKeys.length + axes.costAxes.length).toBe(MAX_AXES);
+  });
+});
+
+describe('sameAxes', () => {
+  it('順序を無視して比較する', () => {
+    expect(
+      sameAxes(
+        { nutrientKeys: ['protein', 'fiber'], costAxes: ['yen'] },
+        { nutrientKeys: ['fiber', 'protein'], costAxes: ['yen'] }
+      )
+    ).toBe(true);
+    expect(
+      sameAxes(
+        { nutrientKeys: ['protein'], costAxes: ['yen'] },
+        { nutrientKeys: ['protein'], costAxes: ['co2eKg'] }
+      )
+    ).toBe(false);
+  });
+});

--- a/src/lib/compare-state.ts
+++ b/src/lib/compare-state.ts
@@ -1,0 +1,120 @@
+import type { NutrientKey } from '@/services/diagnose';
+import {
+  COST_AXES,
+  DEFAULT_COMPARE_AXES,
+  type ComparisonAxes,
+  type CostAxis,
+} from '@/services/domination';
+import type { Basis } from '@/services/nutrient-density';
+
+/**
+ * 比較ページの選択状態（基準・軸・ビュー）と URL クエリの相互変換。
+ * 選択状態は URL を単一の情報源とし、共有・リロード・戻るボタンに耐える。
+ * 不正なクエリは例外にせず、黙って既定値へ丸める（共有リンクの劣化耐性）。
+ */
+
+/** 比較 UI で選択できる栄養軸 */
+export const NUTRIENT_KEYS: NutrientKey[] = [
+  'calories',
+  'protein',
+  'fat',
+  'saturatedFattyAcids',
+  'n6PolyunsaturatedFattyAcids',
+  'n3PolyunsaturatedFattyAcids',
+  'carbohydrates',
+  'fiber',
+  'vitaminA',
+  'vitaminD',
+  'vitaminE',
+  'vitaminK',
+  'vitaminB1',
+  'vitaminB2',
+  'vitaminB6',
+  'vitaminB12',
+  'niacin',
+  'folate',
+  'pantothenicAcid',
+  'biotin',
+  'vitaminC',
+  'nacl',
+  'potassium',
+  'calcium',
+  'magnesium',
+  'phosphorus',
+  'iron',
+  'zinc',
+  'copper',
+  'manganese',
+  'iodine',
+  'selenium',
+  'chromium',
+  'molybdenum',
+];
+
+// 軸は栄養+コスト合計で 2〜5 個。高次元では比較可能対が 2^{1-d} で消えて
+// ほぼ全ノードが antichain 化するため（domination.test.ts で確認済み）。
+export const MIN_AXES = 2;
+export const MAX_AXES = 5;
+
+export type CompareView = 'graph' | 'table';
+
+// 基準の分母に使っている量は全ノードで定数になるため、軸から外す
+export const denominatorNutrientOf = (basis: Basis): NutrientKey | null =>
+  basis === 'perKcal' ? 'calories' : null;
+export const denominatorCostOf = (basis: Basis): CostAxis | null =>
+  basis === 'perYen' ? 'yen' : null;
+
+const isCostAxis = (token: string): token is CostAxis =>
+  (COST_AXES as readonly string[]).includes(token);
+const isNutrientKey = (token: string): token is NutrientKey =>
+  (NUTRIENT_KEYS as readonly string[]).includes(token);
+
+export const parseBasis = (value: string | null): Basis =>
+  value === 'perYen' || value === 'perKcal' ? value : 'per100g';
+
+export const parseView = (value: string | null): CompareView =>
+  value === 'table' ? 'table' : 'graph';
+
+/** 既定の軸から、基準の分母に使っている軸を除いたもの */
+export const defaultAxesFor = (basis: Basis): ComparisonAxes => ({
+  nutrientKeys: DEFAULT_COMPARE_AXES.nutrientKeys.filter(
+    (key) => key !== denominatorNutrientOf(basis)
+  ),
+  costAxes: DEFAULT_COMPARE_AXES.costAxes.filter(
+    (axis) => axis !== denominatorCostOf(basis)
+  ),
+});
+
+/**
+ * ?axes=protein,fiber,yen,co2eKg を解釈する。未知のトークン・重複・
+ * 分母に使っている軸は捨て、MAX_AXES 個で打ち切る。残らなければ既定値。
+ */
+export const parseAxes = (
+  value: string | null,
+  basis: Basis
+): ComparisonAxes => {
+  if (!value) return defaultAxesFor(basis);
+  const tokens = [...new Set(value.split(','))]
+    .filter((token) => isCostAxis(token) || isNutrientKey(token))
+    .filter(
+      (token) =>
+        token !== denominatorNutrientOf(basis) &&
+        token !== denominatorCostOf(basis)
+    )
+    .slice(0, MAX_AXES);
+  if (tokens.length === 0) return defaultAxesFor(basis);
+  return {
+    nutrientKeys: tokens.filter(isNutrientKey),
+    costAxes: tokens.filter(isCostAxis),
+  };
+};
+
+export const serializeAxes = (axes: ComparisonAxes): string =>
+  [...axes.nutrientKeys, ...axes.costAxes].join(',');
+
+/** 順序を無視した軸集合の一致（URL を既定値のとき省略するための判定） */
+export const sameAxes = (a: ComparisonAxes, b: ComparisonAxes): boolean =>
+  a.nutrientKeys.length === b.nutrientKeys.length &&
+  a.costAxes.length === b.costAxes.length &&
+  a.nutrientKeys.every((key) => b.nutrientKeys.includes(key)) &&
+  a.costAxes.every((axis) => b.costAxes.includes(axis));


### PR DESCRIPTION
## 概要

「この軸で見るとこの食品が上位互換」という比較の状態を、URLをコピーするだけで共有できるようにする。SSG構成は変えない（クエリはページを増やさない・`history.replaceState` による shallow 更新のみ）。

## 変更点

- `?basis=perYen&axes=protein,fiber,co2eKg,waterL&view=table` の形式で選択状態をURLクエリと双方向同期
- [src/lib/compare-state.ts](../blob/feat/compare-url-state/src/lib/compare-state.ts) を新設: 選択できる軸の語彙 (NUTRIENT_KEYS)・軸数の上下限・分母規則（1円あたり→価格軸を除外 等）と、クエリの parse/serialize を純関数として集約。food-comparison.tsx からロジックを移設
- 不正・古い共有リンクへの耐性: 未知トークン/重複/分母と衝突する軸は黙って捨て、全滅なら既定値へ（例外は投げない）
- 既定値のパラメータはURLから省略し、既存の `?highlight=`（リコメンド・詳細ページからの導線）は保持
- 更新は `window.history.replaceState`（Next 14.1+ の shallow routing）でページ遷移なし

## 動作確認

- vitest 61件（compare-state の parse/serialize 往復・分母除外・上限打ち切り等 7件を追加）/ tsc / eslint すべて green
- dev サーバーで確認: 操作するとURLが追随（表→ `?view=table`、水を追加→ `axes` に反映、1円あたり→ `yen` が axes から消えて `basis=perYen`）。そのURLを開き直すと 表ビュー・基準・軸4個・価格チップ無効 まで完全に復元、`highlight` も保持

🤖 Generated with [Claude Code](https://claude.com/claude-code)