### PR TITLE
fix: label compare total-cost column with the active basis unit

### DIFF
--- a/src/components/food-comparison.tsx
+++ b/src/components/food-comparison.tsx
@@ -136,7 +136,7 @@ const ComparisonTable = ({
       ? [
           {
             key: { kind: 'totalCost' } as SortKey,
-            label: messages['total cost [yen]'],
+            label: `${messages['total cost']} [${messages.yen}${basisSuffix}]`,
           },
         ]
       : []),

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -149,7 +149,7 @@
   "pesticide residue: present (health impact not assessed)": "pesticide residue: present (health impact not assessed)",
   "dominated": "outperformed",
   "pesticide residue (not assessed)": "pesticide residue (not assessed)",
-  "total cost [yen]": "total cost [JPY]",
+  "total cost": "total cost",
   "boiled": "boiled",
   "roasted": "roasted",
   "dried": "dried",

--- a/src/locales/ja-JP.json
+++ b/src/locales/ja-JP.json
@@ -149,7 +149,7 @@
   "pesticide residue: present (health impact not assessed)": "残留農薬: あり（健康影響 未評価）",
   "dominated": "上位互換あり",
   "pesticide residue (not assessed)": "残留農薬(未評価)",
-  "total cost [yen]": "総コスト [円]",
+  "total cost": "総コスト",
   "boiled": "ゆで",
   "roasted": "焼き",
   "dried": "乾",


### PR DESCRIPTION
## What

比較ページの表ビューで、総コスト列のヘッダが basis によらず「総コスト [円]」(en: `total cost [JPY]`) に固定されていた問題を修正します。

総コスト列の値は他の列と同じく `costVector`（選択中の basis で正規化済み）を `scalarizeCost` で合算したものなので、実際の単位は basis に依存します（perYen → 円/円、perKcal → 円/kcal）。ヘッダを他のコスト列・栄養列と同じ組み立て方（`basisSuffix` を付与）に変更し、単位表記を正確にしました。

## Changes

- `src/components/food-comparison.tsx` — 総コスト列ヘッダを `` `${messages['total cost']} [${messages.yen}${basisSuffix}]` `` に変更
- `src/locales/{ja-JP,en-US}.json` — 単位込みキー `total cost [yen]`（総コスト [円] / total cost [JPY]）を、単位を持たない `total cost`（総コスト / total cost）に置換（旧キーは他に使用箇所なし）

## Result

| basis | 総コスト列 | 価格系列（参考） |
|---|---|---|
| per100g | 総コスト [円] | CO2e [kg] |
| perYen | 総コスト [円/円] | CO2e [kg/円] |
| perKcal | 総コスト [円/kcal] | CO2e [kg/kcal] |

perYen の「[円/円]」は同 basis の価格列と一貫し、1円あたりの総コスト（＝倍率）であることが読み取れます。

## Verification

- `npx tsc --noEmit` ✅
- `npm run test`（vitest）✅ 61 passed / 11 files
- `npm run lint` ✅ 警告0
- プレビューで per100g / perYen / perKcal の3 basis の表ヘッダを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)