### PR TITLE
fix: redirect root path to default locale so the header nav appears

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,37 +1,7 @@
-import { LanguageSwitch } from '@/components/language-switcher';
-import ThemeImage from '@/components/theme-image';
-import { TopPage } from '@/components/top-page';
-import { appConfig, basePath } from '@/config';
-import Link from 'next/link';
-import { Suspense } from 'react';
-import { enUS } from '@/locales';
+import { redirect } from 'next/navigation';
 
-export default async function Home() {
-  return (
-    <>
-      <header
-        style={{ display: 'flex', justifyContent: 'flex-end', gap: '1rem' }}
-      >
-        <Suspense>
-          <LanguageSwitch locale={'en-US'} locales={appConfig.i18n} />
-        </Suspense>
-        <Link
-          href="https://github.com/nwatab/nutrition-optimizer"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="flex items-center gap-2 p-2 rounded-lg hover:bg-emerald-100 transition-colors"
-        >
-          <ThemeImage
-            srcLight={`${basePath}/github-mark.svg`}
-            // srcDark={`${basePath}/github-mark-white.svg`} ToDo
-            srcDark={`${basePath}/github-mark.svg`}
-            alt="GitHub"
-            width={24}
-            height={24}
-          />
-        </Link>
-      </header>
-      <TopPage locale="en-US" messages={enUS} />;
-    </>
-  );
+// 既定ロケールのページ（ヘッダーのタブ等を含む [locale] レイアウト配下）へ集約する。
+// ルート `/` に別実装を持つとヘッダー差異が生じるため、`/en-US` へ寄せる。
+export default function Home() {
+  redirect('/en-US');
 }


### PR DESCRIPTION
## 問題

`https://nwatab.github.io/nutrition-optimizer/ja-JP` にはヘッダー（タブ）が表示されるが、ルート `https://nwatab.github.io/nutrition-optimizer/` には表示されない。

## 原因

`/ja-JP`・`/en-US` は `app/[locale]/layout.tsx` を経由し、そのヘッダーに `SiteNav`（My plan / Food database / Compare のタブ）が含まれる。一方ルート `/` は別実装の `app/page.tsx` + ルートレイアウトで en-US コンテンツを描画しており、ヘッダーが言語スイッチと GitHub リンクだけで `SiteNav` を欠いていた。

## 修正

ルート `/` の重複実装をやめ、既定ロケール `/en-US` へリダイレクトするだけにした。これで既定ロケールも `[locale]` レイアウト（タブ・言語スイッチ・GitHub リンク）配下で配信され、ヘッダー差異が解消する。

## 検証

静的エクスポート（`output: 'export'`）でビルドし、`out/` をそのまま静的配信して確認:

- `/` を開くと `/en-US` に遷移する
- 遷移先にナビのタブが存在し、「My plan」がアクティブ表示になる
- コンソールエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)