### PR TITLE
fix: basePath を単一の情報源に集約し、並べ替えで basePath が落ちる問題を修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,9 +26,8 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm test
+      # basePath は src/lib/base-path.ts が NODE_ENV=production から自動で付ける。
       - run: pnpm build
-        env:
-          NEXT_PUBLIC_BASE_PATH: /nutrition-optimizer
       - uses: actions/upload-pages-artifact@v3
         with:
           path: out

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ If you are unsure whether an idea fits, open an issue first and let's discuss.
 
 Pushing to `main` triggers the [Deploy to GitHub Pages](.github/workflows/deploy.yml) workflow, which builds the static export (`next build` with `output: 'export'`) and publishes the `out/` directory to GitHub Pages.
 
-The site is served under the `/nutrition-optimizer` base path. The workflow sets `NEXT_PUBLIC_BASE_PATH=/nutrition-optimizer` at build time; local `pnpm dev` and `pnpm build` are unaffected and serve from the root.
+The site is served under the `/nutrition-optimizer` base path. The base path lives in a single source of truth, [`src/lib/base-path.ts`](src/lib/base-path.ts), which resolves to `/nutrition-optimizer` for production builds (`NODE_ENV=production`, i.e. `next build`) and `''` for `next dev`. Both `next.config.ts` and the client-side URL helpers derive from it, so config and runtime can't drift. As a result `pnpm build` (local or CI) produces a base-path'd export, while `pnpm dev` serves from the root for clean local URLs.
 
 One-time setup: in the repository settings, set **Settings → Pages → Source** to **GitHub Actions**.
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,8 +1,11 @@
 import type { NextConfig } from 'next';
 
+// basePath は単一の情報源から取る（client の withBasePath と同じ値）。
+import { BASE_PATH } from './src/lib/base-path';
+
 const nextConfig: NextConfig = {
   output: 'export',
-  basePath: process.env.NEXT_PUBLIC_BASE_PATH ?? '',
+  basePath: BASE_PATH,
   images: { unoptimized: true },
   staticPageGenerationTimeout: 180,
 };

--- a/src/components/food-comparison.tsx
+++ b/src/components/food-comparison.tsx
@@ -27,6 +27,7 @@ import {
   hasNonZeroWeights,
   readStoredWeights,
 } from '@/lib/environmental-prices';
+import { withBasePath } from '@/lib/shallow-url';
 import { unitMap } from '@/lib/unitmap';
 import type { Message } from '@/locales';
 import type { NutrientKey } from '@/services/diagnose';
@@ -288,8 +289,7 @@ export default function FoodComparison({
     Object.entries(updates).forEach(([key, value]) =>
       value === null ? params.delete(key) : params.set(key, value)
     );
-    const query = params.toString();
-    window.history.replaceState(null, '', query ? `${pathname}?${query}` : pathname);
+    window.history.replaceState(null, '', withBasePath(pathname, params.toString()));
   };
 
   const changeView = (next: CompareView) =>

--- a/src/components/food-list.tsx
+++ b/src/components/food-list.tsx
@@ -6,6 +6,7 @@ import { useMemo } from 'react';
 
 import { Card, CardContent } from '@/components/ui/card';
 import type { Locale } from '@/config';
+import { withBasePath } from '@/lib/shallow-url';
 import { formatNutrientAmount, unitMap } from '@/lib/unitmap';
 import type { Message } from '@/locales';
 import type { NutrientKey } from '@/services/diagnose';
@@ -123,12 +124,7 @@ export default function FoodList({
     Object.entries(updates).forEach(([key, value]) =>
       value === null ? params.delete(key) : params.set(key, value)
     );
-    const query = params.toString();
-    window.history.replaceState(
-      null,
-      '',
-      query ? `${pathname}?${query}` : pathname
-    );
+    window.history.replaceState(null, '', withBasePath(pathname, params.toString()));
   };
 
   const changeSort = (column: Column) => {

--- a/src/components/recommendation-results.tsx
+++ b/src/components/recommendation-results.tsx
@@ -9,6 +9,7 @@ import NutritionCategoryCharts from '@/components/nutrition-category-charts';
 import NutritionSummary from '@/components/nutrition-summary';
 import { Card, CardContent } from '@/components/ui/card';
 import type { Locale } from '@/config';
+import { BASE_PATH } from '@/lib/base-path';
 import {
   PRICE_PRESETS,
   ZERO_WEIGHTS,
@@ -79,7 +80,7 @@ export default function RecommendationResults({
     // 二重取得にはならない。cleanup で破棄すると自身の setState が取得結果を
     // 捨ててしまうため、あえて破棄しない（unmount 後の setState は無害）。
     setFetchState('loading');
-    fetch(`${process.env.NEXT_PUBLIC_BASE_PATH ?? ''}/api/foods`)
+    fetch(`${BASE_PATH}/api/foods`)
       .then((response) => {
         if (!response.ok) throw new Error(`HTTP ${response.status}`);
         return response.json();

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,5 @@
 import type { AgeBand, PalCategory, Sex } from '@/data';
+import { BASE_PATH } from '@/lib/base-path';
 import type { Message } from '@/locales';
 
 export type Locale = 'en-US' | 'ja-JP';
@@ -118,7 +119,8 @@ export const statusesFor = (
 
 // next/image with `unoptimized` does not prepend basePath, so public
 // assets referenced by absolute path must include it themselves.
-export const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+// 値は単一の情報源（@/lib/base-path）から取る。
+export const basePath = BASE_PATH;
 
 /**
  * フォーム入力（リコメンド URL のセグメント）の sessionStorage 保存先。

--- a/src/lib/base-path.ts
+++ b/src/lib/base-path.ts
@@ -1,0 +1,7 @@
+// GitHub Pages のプロジェクトサイトは /<repo> 配下で配信されるため basePath が要る。
+// basePath の値の「単一の情報源」。next.config.ts（ビルド設定）と client の
+// withBasePath（history.replaceState 用）の両方がここから導出し、食い違いを防ぐ。
+// 本番ビルドのみ basePath を付け、dev はルート配信で URL をクリーンに保つ。
+// next build は NODE_ENV=production、next dev は development で実行される。
+export const BASE_PATH =
+  process.env.NODE_ENV === 'production' ? '/nutrition-optimizer' : '';

--- a/src/lib/shallow-url.ts
+++ b/src/lib/shallow-url.ts
@@ -1,0 +1,12 @@
+// basePath は next/link や router が自動で前置するが、window.history.replaceState は
+// 素のブラウザ API なので前置しない。usePathname() も basePath を含まない値を返すため、
+// シャロー書き換えでは自前で補わないと basePath が URL から落ちる。
+// next.config.ts と同じ単一の情報源（BASE_PATH）を参照する。
+import { BASE_PATH } from '@/lib/base-path';
+
+/**
+ * usePathname() の値とクエリ文字列から、basePath を含むシャロー書き換え用 URL を作る。
+ * query が空なら「?」を付けない。
+ */
+export const withBasePath = (pathname: string, query: string): string =>
+  query ? `${BASE_PATH}${pathname}?${query}` : `${BASE_PATH}${pathname}`;


### PR DESCRIPTION
## 背景 / 症状

GitHub Pages（`/nutrition-optimizer` 配下）で `/foods` の列を並べ替えると、URL から basePath が落ちていた。

- 例: `…/nutrition-optimizer/ja-JP/foods` でエネルギー列をクリック → `…/ja-JP/foods?order=asc`（`/nutrition-optimizer` が消える）

## 原因

並べ替え・カテゴリー絞り込み・compare のビュー切替は `window.history.replaceState` で URL を浅く書き換えている。これは素のブラウザ API で **basePath を前置しない**。`usePathname()` も basePath を含まない値を返すため、両者を単純連結すると basePath が URL から落ちる。`next/link` / `router` は自動前置するので影響を受けていなかった。

さらに、basePath を読む箇所が `next.config.ts` / client fetch / 画像 src と**分散**しており（それぞれ独立に `NEXT_PUBLIC_BASE_PATH` を参照）、client 側の shallow-routing だけが前置を忘れていた。

## 対応：単一の情報源に集約

- `src/lib/base-path.ts` に `BASE_PATH` を集約（`NODE_ENV==='production'` のときだけ `/nutrition-optimizer`、`next dev` は `''`）
- `next.config.ts` / `withBasePath`（shallow-url）/ `config.basePath`（画像 src）/ `/api/foods` fetch がすべてここから導出
- 生の `replaceState` を `withBasePath()` 経由に統一（`food-list` / `food-comparison`）
- 不要になった `NEXT_PUBLIC_BASE_PATH` と workflow の `env` を廃止（build は `NODE_ENV=production` で自動判定）

dev はルート配信のまま（クリーンな URL）、本番のみ basePath という差分を **base-path.ts の1箇所**に閉じ込めた。

## 検証

- `tsc --noEmit`: エラーなし / `pnpm test`: 72 passed
- dev: 並べ替え → `?order=asc` / `?order_by=cost`、compare → `?view=table`（パス保持）
- 本番ビルド `pnpm build`（`NODE_ENV=production`）で `out/` を実検査: アセット・画像・`/api/foods` fetch すべて `/nutrition-optimizer` を前置

🤖 Generated with [Claude Code](https://claude.com/claude-code)